### PR TITLE
test: fix benign corpus CI fail-closed token secret gap

### DIFF
--- a/tests/test_benign_corpus.py
+++ b/tests/test_benign_corpus.py
@@ -19,10 +19,13 @@ def _build_policy():
     old_require = os.environ.get("MVAR_REQUIRE_EXECUTION_TOKEN")
     old_bundle = os.environ.get("MVAR_REQUIRE_SIGNED_POLICY_BUNDLE")
     old_fail_closed = os.environ.get("MVAR_FAIL_CLOSED")
+    old_exec_token_secret = os.environ.get("MVAR_EXEC_TOKEN_SECRET")
 
     os.environ["MVAR_REQUIRE_EXECUTION_TOKEN"] = "1"
     os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] = "0"
     os.environ["MVAR_FAIL_CLOSED"] = "1"
+    # Keep this test self-contained across CI/local environments.
+    os.environ["MVAR_EXEC_TOKEN_SECRET"] = "ci_benign_corpus_secret"
 
     graph = ProvenanceGraph(enable_qseal=False)
     runtime = CapabilityRuntime()
@@ -64,6 +67,11 @@ def _build_policy():
             os.environ.pop("MVAR_FAIL_CLOSED", None)
         else:
             os.environ["MVAR_FAIL_CLOSED"] = old_fail_closed
+
+        if old_exec_token_secret is None:
+            os.environ.pop("MVAR_EXEC_TOKEN_SECRET", None)
+        else:
+            os.environ["MVAR_EXEC_TOKEN_SECRET"] = old_exec_token_secret
 
     return graph, policy, _restore_env
 


### PR DESCRIPTION
## Summary
Fix CI failure on `main` where benign corpus tests were failing with:
- `Fail-closed: execution token secret missing`

The test fixture in `tests/test_benign_corpus.py` enabled execution-token enforcement but did not provide a token secret in clean CI environments.

## Change
- In benign corpus test fixture, set deterministic test-local `MVAR_EXEC_TOKEN_SECRET`.
- Restore previous env value after each test case.

## Scope
- Only test fixture changed.
- No README/docs/features/enforcement logic changes.

## Validation
- `env -u MVAR_EXEC_TOKEN_SECRET python -m pytest -q tests/test_benign_corpus.py` -> 200 passed
- `python -m pytest -q` -> 261 passed
- `./scripts/launch-gate.sh` -> PASS
