### PR TITLE
docs: normalize incident messaging + refresh STATUS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Artifacts: `reports/security_scorecard.json` and [`STATUS.md`](STATUS.md)
 
 ### Network Exposure Guardrails (Ollama/OpenClaw Class)
 
-Public incident class (widely discussed on March 2, 2026): local-model services accidentally exposed by binding to `0.0.0.0` without authentication. Public reporting cited roughly **175,000 exposed instances** in this misconfiguration class.
+Public incident class (widely discussed on March 2, 2026): local-model services accidentally exposed by binding to `0.0.0.0` without authentication, with widespread public reporting of exposed instances in this misconfiguration class.
 
 MVAR now includes deterministic exposure guardrail checks:
 - `mvar-doctor` fails if it detects public bind variables without explicit allow + auth.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # MVAR Security Status
 
-**Last updated:** 2026-03-02T07:37:47.468649+00:00  
-**Version:** 1.2.0  
-**Commit:** e4a4ee51e0dacf9234ae5de1810f23e268c1a2f6
+**Last updated:** 2026-03-04T03:26:55.066368+00:00  
+**Version:** 1.2.1  
+**Commit:** 9f99a895b5818948627ee4c38cced1b521549342
 
 ## Attack Corpus Coverage
 

--- a/demo/info.py
+++ b/demo/info.py
@@ -71,7 +71,7 @@ def _doctor() -> int:
     if not exposure_result.ok:
         print(
             "Guardrail failure: public bind without explicit allow + authentication. "
-            "See March 2, 2026 exposed-instance incident class (~175,000 reported exposures)."
+            "See March 2, 2026 incident class with widespread public reporting of exposed instances."
         )
         status_ok = False
 

--- a/demo/openclaw_cve_defense.py
+++ b/demo/openclaw_cve_defense.py
@@ -303,7 +303,7 @@ def main():
     print_section("SUMMARY")
     print("OpenClaw Prompt Injection:")
     print("   • 1-click Remote Code Execution")
-    print("   • 135,000+ exposed instances worldwide")
+    print("   • Widespread public reporting of exposed instances in this misconfiguration class")
     print("   • Unfixable architectural flaw (credential + execution co-location)")
     print()
     print("MVAR Defense:")

--- a/docs/TWO_WEEK_IMPLEMENTATION_PLAN.md
+++ b/docs/TWO_WEEK_IMPLEMENTATION_PLAN.md
@@ -26,7 +26,7 @@ This plan converts the "secure-by-default + public proof" initiative into a conc
 
 ### Day 5-7: Exposure Guardrails
 - Add deterministic checks for public bind (`0.0.0.0`/`::`) with required explicit allow + auth.
-- Document this as a direct mitigation for the March 2, 2026 incident class (~175,000 reported exposed instances).
+- Document this as a direct mitigation for the March 2, 2026 incident class with widespread public reporting of exposed instances in this misconfiguration class.
 - Enforce via `mvar-doctor` and deployment demo startup path.
 - Add regression tests for:
   - blocked unsafe public bind

--- a/docs/deployment/OPENAI_DOCKER_COOKBOOK.md
+++ b/docs/deployment/OPENAI_DOCKER_COOKBOOK.md
@@ -73,7 +73,7 @@ Expected:
   - `MVAR_ALLOW_PUBLIC_BIND=1`
   - one auth token/key (`MVAR_GATEWAY_AUTH_TOKEN`, `OPENCLAW_API_KEY`, or equivalent)
   - otherwise `mvar-doctor` and startup guardrails fail closed.
-- This guardrail targets the March 2, 2026 incident class (roughly 175,000 reported exposed local-model instances from public-bind misconfiguration).
+- This guardrail targets the March 2, 2026 incident class with widespread public reporting of exposed instances in this misconfiguration class.
 
 ## 5) Failure modes and troubleshooting
 

--- a/docs/releases/v1.2.0.md
+++ b/docs/releases/v1.2.0.md
@@ -18,7 +18,7 @@
 - Added **network exposure guardrails** for public-bind misconfiguration class:
   - deterministic detection of `0.0.0.0` / `::` bind variables
   - explicit allow + auth requirement for intentional public bind
-  - covers the March 2, 2026 incident class (~175,000 reported exposed instances)
+  - covers the March 2, 2026 incident class with widespread public reporting of exposed instances in this misconfiguration class
   - wired into `mvar-doctor`, deployment demo startup checks, and OpenClaw adapter path
 
 ## Trust Proof and CI Artifacts


### PR DESCRIPTION
## Summary
Minimal pre-outreach trust cleanup.

- normalize public-bind incident wording across README/docs/demo
- remove inconsistent uncited exposed-instance counts
- refresh STATUS.md via scorecard pipeline

## Scope
Only docs/demo/status messaging updates:
- README.md
- STATUS.md
- demo/info.py
- demo/openclaw_cve_defense.py
- docs/TWO_WEEK_IMPLEMENTATION_PLAN.md
- docs/deployment/OPENAI_DOCKER_COOKBOOK.md
- docs/releases/v1.2.0.md

No enforcement/runtime/CI/test framework changes.

## Validation
- `python -m pytest -q` -> PASS
- `./scripts/launch-gate.sh` -> PASS

## Main branch health precondition
PR #3 CI fix is merged and `main` matrix checks are green.
