### PR TITLE
ci: fail scorecard step on publish errors

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@e4c423540e964e15ccadc56558705ba15136265c # v2.3.3
-        continue-on-error: true
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from the OpenSSF Scorecard step in `.github/workflows/scorecard.yml`.
- This makes Scorecard publish failures visible instead of silently passing.

## Scope
- [x] CI/workflows
- [ ] mvar-core/
- [ ] mvar_adapters/
- [ ] demo/
- [ ] tests/
- [ ] docs/

## Why
The public Scorecard API remained stuck on an older commit because publish failures were masked. This change makes failures actionable so the Scorecard report reflects current `main`.
