### PR TITLE
ci: pin scorecard action to official v2.3.3 commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@e4c423540e964e15ccadc56558705ba15136265c # v2.3.3
+        uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- Pin `ossf/scorecard-action` to the official v2.3.3 commit SHA in `.github/workflows/scorecard.yml`.
- Fixes Scorecard publish failure: `imposter commit ... does not belong to ossf/scorecard-action`.

## Scope
- [x] CI/workflows
- [ ] mvar-core/
- [ ] mvar_adapters/
- [ ] demo/
- [ ] tests/
- [ ] docs/
