### PR TITLE
ci: pin upload-sarif action to peeled v3.28.17 commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@0fa1882f994fbd81a47ab0804f93354f5ea40147 # v3.28.17
+        uses: github/codeql-action/upload-sarif@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         with:
           sarif_file: results.sarif
 


### PR DESCRIPTION
## Summary
- Fix OpenSSF Scorecard publish verification by pinning `github/codeql-action/upload-sarif` to the official peeled commit SHA for `v3.28.17`.
- This resolves the `imposter commit` error from the Scorecard webapp publish step.

## Scope
- [x] CI/workflows
- [ ] mvar-core/
- [ ] mvar_adapters/
- [ ] demo/
- [ ] tests/
- [ ] docs/

## Why
The Scorecard run was generating results but publish failed with:
`workflow verification failed ... imposter commit ... github/codeql-action/upload-sarif`.
This patch aligns the action pin with Scorecard workflow verification requirements.
