### PR TITLE
ci: use SCORECARD_TOKEN for scorecard workflow auth

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          repo_token: ${{ secrets.SCORECARD_REPO_TOKEN || github.token }}
+          repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}
           publish_results: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Upload SARIF


### PR DESCRIPTION
## Summary
- Update Scorecard workflow to use `SCORECARD_TOKEN` secret for `repo_token` (with fallback to `github.token`).
- Keep existing workflow behavior unchanged otherwise.

## Why
- Improve Scorecard API access to repository branch protection metadata.
- Resolve `Branch-Protection` check failures caused by `Resource not accessible by integration`.

## Change
- `.github/workflows/scorecard.yml`
  - `repo_token: ${{ secrets.SCORECARD_TOKEN || github.token }}`

## Validation
- Workflow syntax unchanged except secret reference.
- Existing required checks remain intact.
