### PR TITLE
docs: restructure README intro and add collapsed attack matrix teaser

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,4 +627,3 @@ GitHub: [@mvar-security](https://github.com/mvar-security)
 ---
 
 *MVAR: Deterministic sink enforcement against prompt-injection-driven tool misuse via information flow control and cryptographic provenance tracking.*
-# Trigger workflows


### PR DESCRIPTION
## Summary
- reorder README top sections so **Verify in 60 Seconds** appears before **Use MVAR in Your Agent (2 Ways)**
- add one blank line between the badge row and the `---` divider
- insert a collapsed `<details>` teaser after the divider with the existing attack validation matrix copied verbatim
- remove leftover `Trigger workflows` marker from README footer

## Scope
- [x] Docs (`README.md`)
- [ ] Code/runtime
- [ ] CI/workflows
- [ ] Tests

## Validation
- confirmed heading order is now:
  1. Title + tagline
  2. Badge row
  3. Divider
  4. Verify in 60 Seconds
  5. Use MVAR in Your Agent (2 Ways)
- confirmed `<details>` block renders collapsed by default with summary line visible
- confirmed blank line exists after `</details>` before next heading
- confirmed anchors still resolve:
  - `#verify-in-60-seconds`
  - `#use-mvar-in-your-agent-2-ways`
- confirmed no wording/code-block changes intended beyond structural move and specified additions
