### PR TITLE
docs: polish README hero and top flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@
 
 # MVAR — Deterministic Security for AI Agents
 
-MVAR prevents prompt-injection attacks from turning LLM output into real system actions.
+**If your agent can run shell commands, call APIs, read files, or use credentials, prompt injection can become real execution.** MVAR prevents that by enforcing deterministic policy between model output and privileged tools. It works with modern agent runtimes, including MCP- and OpenClaw-style tool chains. See the governed runtime proof for a reproducible benign-pass / adversarial-block demo.
+
+Recent agent-runtime incidents have made one thing clear: prompt filtering is not enough once model output can reach execution sinks.
+
+**MVAR is the execution firewall for AI agents.**
+
+Invariant: `UNTRUSTED input + CRITICAL sink -> BLOCK`
+
+[30-Second Proof](#30-second-proof) · [Quick Start](#quick-start) · [Governed MCP Proof](docs/outreach/GOVERNED_MCP_RUNTIME_PROOF.md) · [Adapters](docs/FIRST_PARTY_ADAPTERS.md)
 
 [![Launch Gate](https://github.com/mvar-security/mvar/actions/workflows/launch-gate.yml/badge.svg)](https://github.com/mvar-security/mvar/actions/workflows/launch-gate.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mvar-security/mvar/badge)](https://scorecard.dev/viewer/?uri=github.com/mvar-security/mvar)
@@ -14,22 +22,6 @@ MVAR prevents prompt-injection attacks from turning LLM output into real system 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.md)
 
 ---
-
-MVAR is the execution firewall for AI agents.
-
-It sits between an LLM and privileged tools (shell, APIs, files, credentials) and enforces deterministic policy before privileged actions run.
-
-`50 attack vectors blocked` · `200 benign vectors passed` · `CI-gated launch validation`
-
-**Invariant:** `UNTRUSTED input + CRITICAL sink -> BLOCK`
-
----
-
-- ➡ [30-Second Proof](#30-second-proof)
-- ➡ [Quick Start](#quick-start)
-- ➡ [Validation](#validation)
-- ➡ [Who This Is For](#who-this-is-for)
-- ➡ [Deployment Modes](#deployment-modes-current)
 
 ## 30-Second Proof
 

--- a/docs/outreach/GOVERNED_MCP_RUNTIME_PROOF.md
+++ b/docs/outreach/GOVERNED_MCP_RUNTIME_PROOF.md
@@ -1,0 +1,91 @@
+# Governed AI Runtime: Reproducible MCP Enforcement Proof
+
+This page demonstrates benign-allow / adversarial-block behavior for MCP-style tool execution under governed runtime enforcement. If you are evaluating agent-runtime risk classes discussed around OpenClaw-style incidents, this is the reproducible runtime boundary proof: privileged tool actions are gated by execution-envelope validation, and invalid paths are blocked before execution.
+
+This is runtime enforcement, not prompt filtering. The control point is the privileged execution sink.
+
+The included demo shows:
+
+- benign MCP request: allowed and executed
+- adversarial prompt-injection request: deterministically blocked
+- evidence chain: emitted for both outcomes
+
+This proof focuses on runtime enforcement behavior rather than policy suggestions or prompt filtering.
+
+---
+
+## What This Demonstrates
+
+The governed runtime enforces several invariants:
+
+1. Execution authorization: privileged actions require a validated execution envelope.
+2. Replay protection: envelopes include nonce and expiry checks.
+3. Lineage tracking: handoffs include parent trace identifiers.
+4. Evidence emission: each decision emits verifiable metadata.
+
+These checks occur before tool execution, so prompt manipulation cannot bypass the execution boundary.
+
+---
+
+## Reproduce in One Command
+
+From repo root:
+
+```bash
+python demo/governed_mcp_toolchain_demo.py
+```
+
+Expected assertion fields in output:
+
+- `assertions.benign_allowed = true`
+- `assertions.adversarial_blocked = true`
+- `assertions.adversarial_tool_not_executed = true`
+- `assertions.evidence_present_all = true`
+
+---
+
+## Validation Test
+
+```bash
+pytest -q tests/e2e/test_governed_mcp_toolchain_demo.py
+```
+
+This test validates:
+
+- benign path executes and returns success
+- adversarial path is blocked
+- blocked path has `execution.executed = false`
+- evidence fields exist (`envelope_core_hash`, `envelope_full_hash`, signature algorithm)
+- trace linkage is present for chained governed calls
+
+---
+
+## Runtime Path (Simplified)
+
+```text
+MCP Tool Request
+    |
+    v
+Execution Governor
+    |
+    v
+Verification + Policy
+    |
+    +--> BLOCK --> Evidence emitted
+    |
+    +--> ALLOW --> Tool executes --> Evidence emitted
+```
+
+---
+
+## Current Scope
+
+Shipped now:
+
+- governed MCP demo script
+- E2E test coverage for benign/adversarial behavior
+- CI gate execution + proof artifact emission
+
+Pending manual lock:
+
+- mark `Governed Runtime Contract Gate (Python 3.12)` as required in branch protection on `main`


### PR DESCRIPTION
## Summary
- simplify top badges by removing internal-phase wording
- move validation credibility line above invariant
- add visual divider before 30-second proof
- switch top navigation to arrow-style quick links
- add star callout under proof section
- tighten wording in "What MVAR Is" section

## Scope
- README only (no runtime/code behavior changes)
