### PR TITLE
docs: make adapter install and code paths explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Install first: [INSTALL.md#installation](INSTALL.md#installation)
 
 Then pick an adapter quickstart: [docs/FIRST_PARTY_ADAPTERS.md](docs/FIRST_PARTY_ADAPTERS.md)
 
+Need source + quickstart per adapter: [Adapter Code + Quickstart Map](docs/FIRST_PARTY_ADAPTERS.md#adapter-code--quickstart-map)
+
 ## Architecture At A Glance
 
 ```text

--- a/docs/FIRST_PARTY_ADAPTERS.md
+++ b/docs/FIRST_PARTY_ADAPTERS.md
@@ -4,6 +4,8 @@ MVAR now includes first-party adapter wrappers for common agent ecosystems.
 
 ## Install (Adapters Included)
 
+Adapters are shipped with the main `mvar` package. There is no separate adapter package to install.
+
 Install from source (recommended while developing):
 
 ```bash
@@ -27,7 +29,31 @@ Quick import check:
 python -c "from mvar_adapters import MVARMCPAdapter; print('adapter import ok')"
 ```
 
+Framework note:
+- MVAR adapters wrap your existing agent stack.
+- Install the framework SDK(s) you already use (for example LangChain/OpenAI/CrewAI/MCP/Anthropic/Google ADK).
+- Package names vary by ecosystem; use your framework's install docs.
+
 Full install guide: [../INSTALL.md](../INSTALL.md)
+
+## Adapter Code + Quickstart Map
+
+| Adapter | Wrapper Class | Source Code | Quickstart |
+|---|---|---|---|
+| LangChain | `MVARLangChainAdapter` | [`../mvar_adapters/langchain.py`](../mvar_adapters/langchain.py) | [`../examples/adapters/langchain_quickstart.py`](../examples/adapters/langchain_quickstart.py) |
+| OpenAI tool calling | `MVAROpenAIAdapter` | [`../mvar_adapters/openai.py`](../mvar_adapters/openai.py) | [`../examples/adapters/openai_quickstart.py`](../examples/adapters/openai_quickstart.py) |
+| MCP | `MVARMCPAdapter` | [`../mvar_adapters/mcp.py`](../mvar_adapters/mcp.py) | [`../examples/adapters/mcp_quickstart.py`](../examples/adapters/mcp_quickstart.py) |
+| Claude tool runtime | `MVARClaudeToolAdapter` | [`../mvar_adapters/claude.py`](../mvar_adapters/claude.py) | Use `MVARClaudeToolAdapter` via your tool-dispatch layer |
+| AutoGen | `MVARAutoGenAdapter` | [`../mvar_adapters/autogen.py`](../mvar_adapters/autogen.py) | [`../examples/adapters/autogen_quickstart.py`](../examples/adapters/autogen_quickstart.py) |
+| CrewAI | `MVARCrewAIAdapter` | [`../mvar_adapters/crewai.py`](../mvar_adapters/crewai.py) | [`../examples/adapters/crewai_quickstart.py`](../examples/adapters/crewai_quickstart.py) |
+| OpenClaw | `MVAROpenClawAdapter` | [`../mvar_adapters/openclaw.py`](../mvar_adapters/openclaw.py) | [`../examples/adapters/openclaw_quickstart.py`](../examples/adapters/openclaw_quickstart.py) |
+| Google ADK | `MVARGoogleADKAdapter` | [`../mvar_adapters/google_adk.py`](../mvar_adapters/google_adk.py) | [`../examples/adapters/google_adk_quickstart.py`](../examples/adapters/google_adk_quickstart.py) |
+| OpenAI Agents SDK | `MVAROpenAIAgentsAdapter` | [`../mvar_adapters/openai_agents.py`](../mvar_adapters/openai_agents.py) | [`../examples/adapters/openai_agents_quickstart.py`](../examples/adapters/openai_agents_quickstart.py) |
+
+Related runtime wrappers:
+
+- OpenAI Responses runtime: [`../examples/adapters/openai_responses_runtime_quickstart.py`](../examples/adapters/openai_responses_runtime_quickstart.py)
+- OpenClaw runtime: [`../examples/adapters/openclaw_runtime_quickstart.py`](../examples/adapters/openclaw_runtime_quickstart.py)
 
 ## Included wrappers
 


### PR DESCRIPTION
## Summary
- add explicit install guidance in adapter docs (no separate adapter package)
- add adapter code + quickstart map with direct links per adapter
- add README link to adapter source/quickstart map
- clarify framework SDK install expectation

## Why
Reduce user friction so adapter adoption is copy/paste simple with no hunting.

## Scope
- README.md
- docs/FIRST_PARTY_ADAPTERS.md
