### PR TITLE
security: enforce Ed25519-only mode and require signed policy bundles in strict profile

### DIFF
--- a/mvar-core/policy_bundle.py
+++ b/mvar-core/policy_bundle.py
@@ -5,8 +5,75 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List
+
+_CRYPTO_AVAILABLE = False
+try:
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        PublicFormat,
+        load_pem_private_key,
+        load_pem_public_key,
+    )
+    _CRYPTO_AVAILABLE = True
+except ImportError:
+    _CRYPTO_AVAILABLE = False
+
+
+def _policy_bundle_key_dir() -> Path:
+    raw = os.getenv("MVAR_POLICY_BUNDLE_KEY_DIR", os.getenv("MVAR_QSEAL_DIR", ""))
+    if raw.strip():
+        return Path(raw)
+    return Path.home() / ".mvar" / "policy_bundle"
+
+
+def _load_or_create_ed25519_keypair() -> tuple[Any, Any]:
+    if not _CRYPTO_AVAILABLE:
+        raise RuntimeError("cryptography package not available for Ed25519 policy bundle signing")
+
+    key_dir = _policy_bundle_key_dir()
+    key_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(key_dir, 0o700)
+    except OSError:
+        pass
+
+    priv_path = key_dir / "policy_bundle_private_key.pem"
+    pub_path = key_dir / "policy_bundle_public_key.pem"
+    if priv_path.exists() and pub_path.exists():
+        with open(priv_path, "rb") as handle:
+            private_key = load_pem_private_key(handle.read(), password=None)
+        with open(pub_path, "rb") as handle:
+            public_key = load_pem_public_key(handle.read())
+        return private_key, public_key
+
+    private_key = ed25519.Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    priv_bytes = private_key.private_bytes(
+        encoding=Encoding.PEM,
+        format=PrivateFormat.PKCS8,
+        encryption_algorithm=NoEncryption(),
+    )
+    pub_bytes = public_key.public_bytes(
+        encoding=Encoding.PEM,
+        format=PublicFormat.SubjectPublicKeyInfo,
+    )
+    with open(priv_path, "wb") as handle:
+        handle.write(priv_bytes)
+    with open(pub_path, "wb") as handle:
+        handle.write(pub_bytes)
+    try:
+        os.chmod(priv_path, 0o600)
+        os.chmod(pub_path, 0o600)
+    except OSError:
+        pass
+    return private_key, public_key
 
 
 def canonicalize_sinks(sinks: List[Dict[str, Any]], fail_closed: bool) -> Dict[str, Any]:
@@ -30,28 +97,67 @@ def build_signed_bundle(
     canonical_payload: Dict[str, Any],
     secret: bytes,
     issuer: str = "mvar_policy_bundle",
+    *,
+    enforce_ed25519: bool = False,
 ) -> Dict[str, Any]:
-    """Create signed policy bundle using HMAC-SHA256."""
+    """Create signed policy bundle using HMAC-SHA256 or Ed25519."""
     policy_hash = compute_policy_hash(canonical_payload)
     signed_part = {
         "schema_version": "1.0",
         "issued_at": datetime.now(timezone.utc).isoformat(),
         "issuer": issuer,
-        "algorithm": "hmac-sha256",
         "policy_hash": policy_hash,
         "canonical_policy": canonical_payload,
     }
+    if enforce_ed25519:
+        if not _CRYPTO_AVAILABLE:
+            raise RuntimeError("MVAR_ENFORCE_ED25519=1 requires cryptography for policy bundle signing")
+        private_key, public_key = _load_or_create_ed25519_keypair()
+        signed_part["algorithm"] = "ed25519"
+        public_raw = public_key.public_bytes(encoding=Encoding.Raw, format=PublicFormat.Raw)
+        signed_part["public_key_hex"] = public_raw.hex()
+        payload = json.dumps(signed_part, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        signature = private_key.sign(payload).hex()
+        signed_part["signature"] = signature
+        return signed_part
+
+    signed_part["algorithm"] = "hmac-sha256"
     payload = json.dumps(signed_part, sort_keys=True, separators=(",", ":")).encode("utf-8")
     signature = hmac.new(secret, payload, hashlib.sha256).hexdigest()
     signed_part["signature"] = signature
     return signed_part
 
 
-def verify_signed_bundle(bundle: Dict[str, Any], secret: bytes) -> bool:
+def verify_signed_bundle(bundle: Dict[str, Any], secret: bytes, *, enforce_ed25519: bool = False) -> bool:
     """Verify signed policy bundle authenticity and internal consistency."""
-    if not bundle or bundle.get("algorithm") != "hmac-sha256":
+    if not bundle:
+        return False
+    algorithm = str(bundle.get("algorithm", "")).lower()
+    if enforce_ed25519 and algorithm != "ed25519":
         return False
     if "signature" not in bundle or "canonical_policy" not in bundle:
+        return False
+
+    if algorithm == "ed25519":
+        if not _CRYPTO_AVAILABLE:
+            return False
+        signature_hex = str(bundle.get("signature", ""))
+        public_key_hex = str(bundle.get("public_key_hex", ""))
+        if not signature_hex or not public_key_hex:
+            return False
+        signed_portion = {k: v for k, v in bundle.items() if k != "signature"}
+        payload = json.dumps(signed_portion, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        try:
+            public_key = ed25519.Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key_hex))
+            public_key.verify(bytes.fromhex(signature_hex), payload)
+        except Exception:
+            return False
+        canonical = bundle.get("canonical_policy")
+        if not isinstance(canonical, dict):
+            return False
+        return str(bundle.get("policy_hash", "")) == compute_policy_hash(canonical)
+
+    if algorithm != "hmac-sha256":
         return False
     signed_portion = {k: v for k, v in bundle.items() if k != "signature"}
     payload = json.dumps(signed_portion, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/mvar-core/profiles.py
+++ b/mvar-core/profiles.py
@@ -27,17 +27,18 @@ class SecurityProfile(str, Enum):
 PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     SecurityProfile.STRICT: {
         "MVAR_FAIL_CLOSED": "1",
+        "MVAR_ENFORCE_ED25519": "1",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "1",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "1",
         "MVAR_EXECUTION_TOKEN_NONCE_PERSIST": "1",
         "MVAR_ENABLE_COMPOSITION_RISK": "1",
         "MVAR_REQUIRE_DECLASSIFY_TOKEN": "1",
         "MVAR_DECLASSIFY_TOKEN_ONE_TIME": "1",
-        # Keep optional by default to avoid accidental hard lockouts in local quickstarts.
-        "MVAR_REQUIRE_SIGNED_POLICY_BUNDLE": "0",
+        "MVAR_REQUIRE_SIGNED_POLICY_BUNDLE": "1",
     },
     SecurityProfile.BALANCED: {
         "MVAR_FAIL_CLOSED": "1",
+        "MVAR_ENFORCE_ED25519": "0",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "1",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "1",
         "MVAR_EXECUTION_TOKEN_NONCE_PERSIST": "0",
@@ -48,6 +49,7 @@ PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     },
     SecurityProfile.MONITOR: {
         "MVAR_FAIL_CLOSED": "1",
+        "MVAR_ENFORCE_ED25519": "0",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "0",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "0",
         "MVAR_EXECUTION_TOKEN_NONCE_PERSIST": "0",

--- a/mvar-core/qseal.py
+++ b/mvar-core/qseal.py
@@ -159,7 +159,14 @@ class QSealSigner:
         self._private_key: Optional[Any] = None
         self._public_key: Optional[Any] = None
         self._public_key_hex: str = ""
+        self._enforce_ed25519 = os.getenv("MVAR_ENFORCE_ED25519", "0") == "1"
         self._algorithm = "ed25519" if _CRYPTO_AVAILABLE else "hmac-sha256"
+
+        if self._enforce_ed25519 and not _CRYPTO_AVAILABLE:
+            raise RuntimeError(
+                "MVAR_ENFORCE_ED25519=1 requires the 'cryptography' package "
+                "(Ed25519 unavailable; refusing HMAC fallback)"
+            )
 
         try:
             if _CRYPTO_AVAILABLE:
@@ -173,6 +180,12 @@ class QSealSigner:
                 self._init_ed25519_keys()
             else:
                 self._init_hmac_fallback()
+
+        if self._enforce_ed25519 and self._algorithm != "ed25519":
+            raise RuntimeError(
+                "MVAR_ENFORCE_ED25519=1 requires Ed25519 signer initialization; "
+                "fallback algorithms are not permitted"
+            )
 
         logger.info(
             "QSealSigner initialized | algorithm=%s | key_dir=%s",

--- a/mvar-core/sink_policy.py
+++ b/mvar-core/sink_policy.py
@@ -261,6 +261,7 @@ class SinkPolicy:
         self.max_blob_len = int(os.getenv("MVAR_MAX_BLOB_LEN", "32768"))
         self._expected_policy_hash = os.getenv("MVAR_EXPECTED_POLICY_HASH", "").strip()
         self.require_signed_policy_bundle = os.getenv("MVAR_REQUIRE_SIGNED_POLICY_BUNDLE", "0") == "1"
+        self.enforce_ed25519 = os.getenv("MVAR_ENFORCE_ED25519", "0") == "1"
         self.policy_bundle_path = os.getenv("MVAR_POLICY_BUNDLE_PATH", "").strip()
         self._policy_bundle_secret = os.getenv(
             "MVAR_POLICY_BUNDLE_SECRET",
@@ -674,7 +675,7 @@ class SinkPolicy:
 
     def write_signed_policy_bundle(self, bundle_path: Optional[str] = None, issuer: str = "mvar_runtime") -> Dict[str, Any]:
         """Emit signed policy bundle for deterministic startup verification."""
-        if not self._policy_bundle_secret:
+        if not self._policy_bundle_secret and not self.enforce_ed25519:
             raise RuntimeError("policy bundle secret missing")
         target_path = bundle_path or self.policy_bundle_path
         if not target_path:
@@ -683,6 +684,7 @@ class SinkPolicy:
             canonical_payload=self._canonical_policy_payload(),
             secret=self._policy_bundle_secret,
             issuer=issuer,
+            enforce_ed25519=self.enforce_ed25519,
         )
         path = Path(target_path)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -705,7 +707,7 @@ class SinkPolicy:
             return None
         if not self.policy_bundle_path:
             return "Signed policy bundle required but MVAR_POLICY_BUNDLE_PATH is unset"
-        if not self._policy_bundle_secret:
+        if not self._policy_bundle_secret and not self.enforce_ed25519:
             return "Signed policy bundle required but secret is missing"
 
         bundle_file = Path(self.policy_bundle_path)
@@ -716,7 +718,14 @@ class SinkPolicy:
         except Exception as exc:
             return f"Signed policy bundle parse failed: {exc}"
 
-        if not verify_signed_bundle(bundle, self._policy_bundle_secret):
+        if self.enforce_ed25519 and str(bundle.get("algorithm", "")).lower() != "ed25519":
+            return "Signed policy bundle must use algorithm=ed25519 when MVAR_ENFORCE_ED25519=1"
+        if not verify_signed_bundle(bundle, self._policy_bundle_secret, enforce_ed25519=self.enforce_ed25519):
+            if self.enforce_ed25519:
+                return (
+                    "Signed policy bundle signature verification failed "
+                    "(Ed25519 required; ensure cryptography/public key configuration is valid)"
+                )
             return "Signed policy bundle signature verification failed"
         bundle_hash = str(bundle.get("policy_hash", ""))
         if bundle_hash != policy_hash:

--- a/tests/test_policy_bundle_gate.py
+++ b/tests/test_policy_bundle_gate.py
@@ -4,17 +4,22 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 import test_common  # noqa: F401
 from capability import CapabilityGrant, CapabilityRuntime, CapabilityType
+from policy_bundle import build_signed_bundle
 from provenance import ProvenanceGraph, provenance_user_input
 from sink_policy import PolicyOutcome, SinkPolicy, register_common_sinks
 
 
-def _build_policy(bundle_path: str, require_bundle: bool, secret: str):
+def _build_policy(bundle_path: str, require_bundle: bool, secret: str, enforce_ed25519: bool = False):
     tracked = [
         "MVAR_REQUIRE_SIGNED_POLICY_BUNDLE",
+        "MVAR_ENFORCE_ED25519",
         "MVAR_POLICY_BUNDLE_PATH",
         "MVAR_POLICY_BUNDLE_SECRET",
+        "MVAR_POLICY_BUNDLE_KEY_DIR",
         "MVAR_ENABLE_LEDGER",
         "MVAR_ENABLE_TRUST_ORACLE",
         "MVAR_FAIL_CLOSED",
@@ -22,8 +27,10 @@ def _build_policy(bundle_path: str, require_bundle: bool, secret: str):
     previous = {key: os.environ.get(key) for key in tracked}
 
     os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] = "1" if require_bundle else "0"
+    os.environ["MVAR_ENFORCE_ED25519"] = "1" if enforce_ed25519 else "0"
     os.environ["MVAR_POLICY_BUNDLE_PATH"] = bundle_path
     os.environ["MVAR_POLICY_BUNDLE_SECRET"] = secret
+    os.environ["MVAR_POLICY_BUNDLE_KEY_DIR"] = str(Path(bundle_path).parent / "bundle_keys")
     os.environ["MVAR_ENABLE_LEDGER"] = "0"
     os.environ["MVAR_ENABLE_TRUST_ORACLE"] = "0"
     os.environ["MVAR_FAIL_CLOSED"] = "1"
@@ -104,5 +111,53 @@ def test_tampered_signed_policy_bundle_blocks_startup(tmp_path: Path):
         )
         assert decision.outcome == PolicyOutcome.BLOCK
         assert "startup policy verification failed" in decision.reason.lower()
+    finally:
+        restore()
+
+
+def test_strict_ed25519_mode_rejects_hmac_bundle(tmp_path: Path):
+    bundle_path = str(tmp_path / "hmac_bundle.json")
+    policy, node_id, restore = _build_policy(
+        bundle_path,
+        require_bundle=True,
+        secret="bundle_secret",
+        enforce_ed25519=True,
+    )
+    try:
+        canonical = policy._canonical_policy_payload()
+        hmac_bundle = build_signed_bundle(canonical, b"bundle_secret", issuer="pytest", enforce_ed25519=False)
+        Path(bundle_path).write_text(json.dumps(hmac_bundle, sort_keys=True), encoding="utf-8")
+
+        decision = policy.evaluate(
+            tool="filesystem",
+            action="read",
+            target="/tmp/report.txt",
+            provenance_node_id=node_id,
+        )
+        assert decision.outcome == PolicyOutcome.BLOCK
+        assert "algorithm=ed25519" in decision.reason
+    finally:
+        restore()
+
+
+def test_strict_ed25519_mode_accepts_ed25519_bundle(tmp_path: Path):
+    pytest.importorskip("cryptography")
+    bundle_path = str(tmp_path / "ed25519_bundle.json")
+    policy, node_id, restore = _build_policy(
+        bundle_path,
+        require_bundle=True,
+        secret="bundle_secret",
+        enforce_ed25519=True,
+    )
+    try:
+        policy.write_signed_policy_bundle(bundle_path, issuer="pytest")
+        decision = policy.evaluate(
+            tool="filesystem",
+            action="read",
+            target="/tmp/report.txt",
+            provenance_node_id=node_id,
+        )
+        assert decision.outcome == PolicyOutcome.ALLOW
+        assert any("startup_policy_verification: ok" in line for line in decision.evaluation_trace)
     finally:
         restore()

--- a/tests/test_qseal_enforce_ed25519.py
+++ b/tests/test_qseal_enforce_ed25519.py
@@ -1,0 +1,14 @@
+"""QSEAL strict Ed25519 enforcement regression tests."""
+
+import pytest
+
+import test_common  # noqa: F401
+import qseal
+
+
+def test_enforce_ed25519_refuses_hmac_fallback(monkeypatch):
+    monkeypatch.setenv("MVAR_ENFORCE_ED25519", "1")
+    monkeypatch.setattr(qseal, "_CRYPTO_AVAILABLE", False)
+
+    with pytest.raises(RuntimeError, match="MVAR_ENFORCE_ED25519=1"):
+        qseal.QSealSigner()

--- a/tests/test_security_profiles.py
+++ b/tests/test_security_profiles.py
@@ -10,6 +10,7 @@ from sink_policy import PolicyOutcome
 
 _PROFILE_KEYS = {
     "MVAR_FAIL_CLOSED",
+    "MVAR_ENFORCE_ED25519",
     "MVAR_REQUIRE_EXECUTION_TOKEN",
     "MVAR_EXECUTION_TOKEN_ONE_TIME",
     "MVAR_EXECUTION_TOKEN_NONCE_PERSIST",
@@ -36,6 +37,8 @@ def test_profile_summary_contains_expected_keys():
     summary = profile_summary(SecurityProfile.STRICT)
     assert summary["MVAR_REQUIRE_EXECUTION_TOKEN"] == "1"
     assert summary["MVAR_ENABLE_COMPOSITION_RISK"] == "1"
+    assert summary["MVAR_ENFORCE_ED25519"] == "1"
+    assert summary["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] == "1"
 
 
 def test_apply_profile_balanced_sets_core_hardening():
@@ -45,6 +48,16 @@ def test_apply_profile_balanced_sets_core_hardening():
         assert os.environ["MVAR_REQUIRE_EXECUTION_TOKEN"] == "1"
         assert os.environ["MVAR_ENABLE_COMPOSITION_RISK"] == "1"
         assert os.environ["MVAR_EXECUTION_TOKEN_NONCE_PERSIST"] == "0"
+    finally:
+        _restore_env(snap)
+
+
+def test_apply_profile_strict_enables_enterprise_roots():
+    snap = _snapshot_env()
+    try:
+        apply_profile(SecurityProfile.STRICT)
+        assert os.environ["MVAR_ENFORCE_ED25519"] == "1"
+        assert os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] == "1"
     finally:
         _restore_env(snap)
 


### PR DESCRIPTION
## What this changes

- MVAR_ENFORCE_ED25519=1 disables HMAC fallback in strict/enterprise mode
- strict profile now requires a signed policy bundle at runtime startup
- Loud failure paths with actionable error messages for both conditions

## Why

HMAC fallback is disabled in strict mode because HMAC is symmetric and 
requires shared-secret distribution, which increases key-management and 
tenant-isolation risk in enterprise deployments. Ed25519 uses asymmetric 
signing, allowing policy authenticity verification without sharing signing 
secrets across runtime boundaries.

## Security impact

This closes an important assurance gap by ensuring that strict-mode policy
evaluation is rooted in authenticated policy artifacts and asymmetric
verification only.

## Validation

- 293 tests passing (full proof pack green)
- Attack corpus: 50/50 blocked
- Launch gate: PASS
- New test coverage:
  - Ed25519-only failure path (loud error when crypto unavailable)
  - Missing bundle → actionable block reason
  - HMAC bundle rejected under strict Ed25519 mode
  - Valid Ed25519 bundle accepted
  - Downgrade path covered by strict-mode enforcement tests

## Scope

Strictly limited to profiles.py, qseal.py, policy_bundle.py, 
sink_policy.py, and associated tests. No API surface changes.
