### PR TITLE
release: prepare v1.3.0 changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to MVAR are documented in `docs/releases/`.
+
+## v1.3.0
+
+- Strict-mode enterprise hardening:
+  - Ed25519-only enforcement in strict profile
+  - Mandatory signed policy bundles in strict profile
+  - Explicit fail-closed startup errors for missing/invalid strict prerequisites
+
+Full release notes: [docs/releases/v1.3.0.md](docs/releases/v1.3.0.md)
+
+## Previous releases
+
+- [v1.2.2](docs/releases/v1.2.2.md)
+- [v1.2.0](docs/releases/v1.2.0.md)
+- [v1.1.0](docs/releases/v1.1.0.md)
+- [v1.0.4](docs/releases/v1.0.4.md)

--- a/docs/releases/UNRELEASED.md
+++ b/docs/releases/UNRELEASED.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Post-v1.3.0
+
+- Release `v1.3.0` cut with strict-mode enterprise hardening.
+- See [v1.3.0 release notes](./v1.3.0.md) for shipped changes.
+
 ## Maintainer and Adoption Hygiene
 
 - Added integration-request intake template:

--- a/docs/releases/v1.3.0.md
+++ b/docs/releases/v1.3.0.md
@@ -1,0 +1,32 @@
+# MVAR v1.3.0 — Strict-Mode Enterprise Hardening
+
+## Validation Snapshot
+
+- Launch gate: PASS
+- Attack corpus: 50/50 blocked
+- Red-team gate: 7/7 passing
+- Full suite: 283 passing (launch-gate run)
+
+## New
+
+- Strict profile now enforces Ed25519-only signing mode (`MVAR_ENFORCE_ED25519=1`)
+- Strict profile now requires signed policy bundle verification at runtime startup
+- Clear fail-closed error behavior for:
+  - crypto unavailable under Ed25519 enforcement
+  - missing/invalid signed policy bundles
+  - algorithm downgrade attempts
+
+## Security Impact
+
+- Eliminates HMAC fallback in strict mode.
+- Requires authenticated policy roots for strict-mode policy evaluation.
+- Hardens startup trust boundary from "optional assurance" to "mandatory assurance" in strict deployments.
+
+## Why this matters
+
+HMAC is symmetric and requires shared-secret distribution, which increases key-management and tenant-isolation risk in enterprise deployments. Ed25519 asymmetric signing enables policy authenticity verification without distributing signing secrets across runtime boundaries.
+
+## Compatibility
+
+- No breaking API surface changes.
+- Strict-mode behavior is intentionally stronger and may block startup until signed policy prerequisites are configured.

--- a/mvar-core/__init__.py
+++ b/mvar-core/__init__.py
@@ -1,5 +1,5 @@
 # MVAR Core - Information Flow Control for AI Agents
-__version__ = "1.2.3"
+__version__ = "1.3.0"
 
 try:
     from .profiles import SecurityProfile, apply_profile, create_default_runtime, profile_summary

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = readme_file.read_text(encoding="utf-8") if readme_file.exists
 
 setup(
     name="mvar",
-    version="1.2.3",
+    version="1.3.0",
     author="Shawn Cohen",
     author_email="security@mvar.io",
     description="MVAR: Information Flow Control for LLM Agent Runtimes — Deterministic prompt injection defense via dual-lattice IFC with cryptographic provenance",


### PR DESCRIPTION
## What this changes

- bumps package/runtime version from `1.2.3` to `1.3.0`
- adds top-level `CHANGELOG.md` with version index
- adds `docs/releases/v1.3.0.md`
- marks `UNRELEASED` as post-v1.3.0 context

## Why

PR #49 introduced strict-mode enterprise hardening (Ed25519-only enforcement + mandatory signed policy bundle verification). This is additive capability and warrants a minor release.

## Validation

- release integrity check passes (`setup.py` version matches `mvar-core/__version__`)
- launch gate is green on main after PR #49

## Notes

This release prep intentionally reflects what is merged on `main`.
`mvar-verify-witness` is not included in this release branch yet.
