### PR TITLE
security: default HTTP egress deny unless allowlisted in strict/enterprise profiles

### DIFF
--- a/mvar-core/profiles.py
+++ b/mvar-core/profiles.py
@@ -28,6 +28,7 @@ PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     SecurityProfile.STRICT: {
         "MVAR_FAIL_CLOSED": "1",
         "MVAR_ENFORCE_ED25519": "1",
+        "MVAR_HTTP_DEFAULT_DENY": "1",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "1",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "1",
         "MVAR_EXECUTION_TOKEN_NONCE_PERSIST": "1",
@@ -39,6 +40,7 @@ PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     SecurityProfile.BALANCED: {
         "MVAR_FAIL_CLOSED": "1",
         "MVAR_ENFORCE_ED25519": "0",
+        "MVAR_HTTP_DEFAULT_DENY": "0",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "1",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "1",
         "MVAR_EXECUTION_TOKEN_NONCE_PERSIST": "0",
@@ -50,6 +52,7 @@ PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     SecurityProfile.MONITOR: {
         "MVAR_FAIL_CLOSED": "1",
         "MVAR_ENFORCE_ED25519": "0",
+        "MVAR_HTTP_DEFAULT_DENY": "0",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "0",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "0",
         "MVAR_EXECUTION_TOKEN_NONCE_PERSIST": "0",

--- a/mvar-core/sink_policy.py
+++ b/mvar-core/sink_policy.py
@@ -262,6 +262,8 @@ class SinkPolicy:
         self._expected_policy_hash = os.getenv("MVAR_EXPECTED_POLICY_HASH", "").strip()
         self.require_signed_policy_bundle = os.getenv("MVAR_REQUIRE_SIGNED_POLICY_BUNDLE", "0") == "1"
         self.enforce_ed25519 = os.getenv("MVAR_ENFORCE_ED25519", "0") == "1"
+        self.http_default_deny = os.getenv("MVAR_HTTP_DEFAULT_DENY", "0") == "1"
+        self.http_allowlist = self._parse_domain_allowlist(os.getenv("MVAR_HTTP_ALLOWLIST", ""))
         self.policy_bundle_path = os.getenv("MVAR_POLICY_BUNDLE_PATH", "").strip()
         self._policy_bundle_secret = os.getenv(
             "MVAR_POLICY_BUNDLE_SECRET",
@@ -373,6 +375,18 @@ class SinkPolicy:
             except Exception:
                 blobs.append(str(parameters))
         return [b[:self.max_blob_len] for b in blobs]
+
+    @staticmethod
+    def _parse_domain_allowlist(raw: str) -> List[str]:
+        return [domain.strip().lower() for domain in str(raw).split(",") if domain.strip()]
+
+    def _effective_http_allowlist(self, sink: SinkClassification) -> List[str]:
+        if self.http_allowlist:
+            return list(self.http_allowlist)
+        metadata_domains = sink.metadata.get("allowed_domains", [])
+        if not isinstance(metadata_domains, list):
+            return []
+        return [str(domain).strip().lower() for domain in metadata_domains if str(domain).strip()]
 
     def _contains_encoded_secret_payload(self, blobs: List[str]) -> bool:
         b64_re = re.compile(r"\b[A-Za-z0-9+/]{24,}={0,2}\b")
@@ -783,7 +797,9 @@ class SinkPolicy:
                 return "missing egress hostname"
             if hostname in {"localhost", "127.0.0.1"} or hostname.startswith("10.") or hostname.startswith("192.168."):
                 return f"private egress target denied: {hostname}"
-            allowed_domains = sink.metadata.get("allowed_domains", [])
+            allowed_domains = self._effective_http_allowlist(sink)
+            if self.http_default_deny and not allowed_domains:
+                return "http egress allowlist required (set MVAR_HTTP_ALLOWLIST)"
             if allowed_domains:
                 allowed = any(
                     hostname == domain or (domain.startswith("*.") and hostname.endswith(domain[1:]))

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 
 import test_common  # noqa: F401
-from capability import CapabilityRuntime, build_shell_tool
+from capability import CapabilityRuntime, CapabilityGrant, CapabilityType, build_shell_tool
 from decision_ledger import MVARDecisionLedger
 from provenance import ProvenanceGraph, provenance_user_input
 from sink_policy import SinkPolicy, register_common_sinks, PolicyOutcome
@@ -91,3 +91,100 @@ def test_ledger_requires_qseal_secret_in_hmac_mode():
     finally:
         if old_secret is not None:
             os.environ["QSEAL_SECRET"] = old_secret
+
+
+def _snapshot_http_env():
+    keys = (
+        "MVAR_HTTP_DEFAULT_DENY",
+        "MVAR_HTTP_ALLOWLIST",
+        "MVAR_REQUIRE_SIGNED_POLICY_BUNDLE",
+    )
+    return {key: os.environ.get(key) for key in keys}
+
+
+def _restore_http_env(snapshot):
+    for key, value in snapshot.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _build_http_policy():
+    graph = ProvenanceGraph(enable_qseal=False)
+    runtime = CapabilityRuntime()
+    runtime.register_tool(
+        "http",
+        capabilities=[
+            CapabilityGrant(
+                cap_type=CapabilityType.NETWORK_EGRESS,
+                allowed_targets=["*"],
+            )
+        ],
+    )
+    policy = SinkPolicy(runtime, graph, enable_qseal=False)
+    register_common_sinks(policy)
+    node = provenance_user_input(graph, "send status update")
+    return graph, policy, node
+
+
+def test_http_egress_default_deny_requires_allowlist():
+    snap = _snapshot_http_env()
+    try:
+        os.environ["MVAR_HTTP_DEFAULT_DENY"] = "1"
+        os.environ["MVAR_HTTP_ALLOWLIST"] = ""
+        os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] = "0"
+        _graph, policy, node = _build_http_policy()
+
+        decision = policy.evaluate(
+            tool="http",
+            action="post",
+            target="https://api.example.com/v1/upload",
+            provenance_node_id=node.node_id,
+        )
+
+        assert decision.outcome == PolicyOutcome.BLOCK
+        assert "allowlist required" in decision.reason.lower()
+    finally:
+        _restore_http_env(snap)
+
+
+def test_http_egress_allowlist_allows_matching_domain():
+    snap = _snapshot_http_env()
+    try:
+        os.environ["MVAR_HTTP_DEFAULT_DENY"] = "1"
+        os.environ["MVAR_HTTP_ALLOWLIST"] = "api.example.com,*.trusted.example"
+        os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] = "0"
+        _graph, policy, node = _build_http_policy()
+
+        decision = policy.evaluate(
+            tool="http",
+            action="post",
+            target="https://api.example.com/v1/upload",
+            provenance_node_id=node.node_id,
+        )
+
+        assert decision.outcome == PolicyOutcome.ALLOW
+    finally:
+        _restore_http_env(snap)
+
+
+def test_http_egress_allowlist_blocks_non_matching_domain():
+    snap = _snapshot_http_env()
+    try:
+        os.environ["MVAR_HTTP_DEFAULT_DENY"] = "1"
+        os.environ["MVAR_HTTP_ALLOWLIST"] = "api.example.com"
+        os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] = "0"
+        _graph, policy, node = _build_http_policy()
+
+        decision = policy.evaluate(
+            tool="http",
+            action="post",
+            target="https://evil.example.net/exfil",
+            provenance_node_id=node.node_id,
+        )
+
+        assert decision.outcome == PolicyOutcome.BLOCK
+        assert "outside allowlist" in decision.reason.lower()
+    finally:
+        _restore_http_env(snap)

--- a/tests/test_security_profiles.py
+++ b/tests/test_security_profiles.py
@@ -11,6 +11,7 @@ from sink_policy import PolicyOutcome
 _PROFILE_KEYS = {
     "MVAR_FAIL_CLOSED",
     "MVAR_ENFORCE_ED25519",
+    "MVAR_HTTP_DEFAULT_DENY",
     "MVAR_REQUIRE_EXECUTION_TOKEN",
     "MVAR_EXECUTION_TOKEN_ONE_TIME",
     "MVAR_EXECUTION_TOKEN_NONCE_PERSIST",
@@ -39,6 +40,7 @@ def test_profile_summary_contains_expected_keys():
     assert summary["MVAR_ENABLE_COMPOSITION_RISK"] == "1"
     assert summary["MVAR_ENFORCE_ED25519"] == "1"
     assert summary["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] == "1"
+    assert summary["MVAR_HTTP_DEFAULT_DENY"] == "1"
 
 
 def test_apply_profile_balanced_sets_core_hardening():
@@ -48,6 +50,7 @@ def test_apply_profile_balanced_sets_core_hardening():
         assert os.environ["MVAR_REQUIRE_EXECUTION_TOKEN"] == "1"
         assert os.environ["MVAR_ENABLE_COMPOSITION_RISK"] == "1"
         assert os.environ["MVAR_EXECUTION_TOKEN_NONCE_PERSIST"] == "0"
+        assert os.environ["MVAR_HTTP_DEFAULT_DENY"] == "0"
     finally:
         _restore_env(snap)
 
@@ -58,6 +61,7 @@ def test_apply_profile_strict_enables_enterprise_roots():
         apply_profile(SecurityProfile.STRICT)
         assert os.environ["MVAR_ENFORCE_ED25519"] == "1"
         assert os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] == "1"
+        assert os.environ["MVAR_HTTP_DEFAULT_DENY"] == "1"
     finally:
         _restore_env(snap)
 


### PR DESCRIPTION
## What this changes

- Adds default-deny behavior for outbound HTTP egress in the strict profile.
- Introduces explicit domain allowlist control for HTTP sinks (`MVAR_HTTP_ALLOWLIST`).
- Blocks non-allowlisted outbound domains with clear, actionable error messages.
- Fails closed when strict default-deny is enabled without an allowlist being configured.
- Keeps balanced and monitor behavior unchanged to avoid breaking first-time adoption flows.

## Why

Most agent exfiltration and command-and-control paths use outbound HTTP.
Strict-mode assurance is incomplete if policy authenticity is enforced but
unrestricted egress remains possible.

This PR closes that gap by making outbound HTTP authorization explicit in
the strict profile.

## Security impact

- Reduces data exfiltration risk via arbitrary outbound requests.
- Enforces least-privilege network behavior for privileged agent actions.
- Improves auditability by making allow/deny decisions deterministic at the sink boundary.
- Strengthens the runtime trust boundary by requiring explicit egress intent in hardened mode.

## Behavior matrix

| Profile | HTTP Egress Default | Allowlist Required |
|---|---|---|
| balanced | allow | no |
| monitor | allow | no |
| strict | deny | yes |

## Validation

- `tests/test_security_profiles.py`
- `tests/test_security_hardening.py`
- `tests/test_api_contracts.py`

All passing locally in this branch.

## Scope

Limited to HTTP sink policy enforcement, profile configuration, and tests.
No API surface expansion beyond egress policy configuration.
