### PR TITLE
security: require verified execution contracts for privileged sink calls

### DIFF
--- a/mvar-core/profiles.py
+++ b/mvar-core/profiles.py
@@ -28,6 +28,7 @@ PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     SecurityProfile.STRICT: {
         "MVAR_FAIL_CLOSED": "1",
         "MVAR_ENFORCE_ED25519": "1",
+        "MVAR_REQUIRE_EXECUTION_CONTRACT": "1",
         "MVAR_HTTP_DEFAULT_DENY": "1",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "1",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "1",
@@ -40,6 +41,7 @@ PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     SecurityProfile.BALANCED: {
         "MVAR_FAIL_CLOSED": "1",
         "MVAR_ENFORCE_ED25519": "0",
+        "MVAR_REQUIRE_EXECUTION_CONTRACT": "0",
         "MVAR_HTTP_DEFAULT_DENY": "0",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "1",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "1",
@@ -52,6 +54,7 @@ PROFILE_ENV: Dict[SecurityProfile, Dict[str, str]] = {
     SecurityProfile.MONITOR: {
         "MVAR_FAIL_CLOSED": "1",
         "MVAR_ENFORCE_ED25519": "0",
+        "MVAR_REQUIRE_EXECUTION_CONTRACT": "0",
         "MVAR_HTTP_DEFAULT_DENY": "0",
         "MVAR_REQUIRE_EXECUTION_TOKEN": "0",
         "MVAR_EXECUTION_TOKEN_ONE_TIME": "0",

--- a/mvar-core/sink_policy.py
+++ b/mvar-core/sink_policy.py
@@ -274,6 +274,7 @@ class SinkPolicy:
         self.execution_token_ttl_seconds = int(os.getenv("MVAR_EXECUTION_TOKEN_TTL_SECONDS", "300"))
         self.execution_token_one_time = os.getenv("MVAR_EXECUTION_TOKEN_ONE_TIME", "1") == "1"
         self.execution_token_nonce_persist = os.getenv("MVAR_EXECUTION_TOKEN_NONCE_PERSIST", "0") == "1"
+        self.require_execution_contract = os.getenv("MVAR_REQUIRE_EXECUTION_CONTRACT", "0") == "1"
         self.execution_token_nonce_store_path = os.getenv(
             "MVAR_EXEC_TOKEN_NONCE_STORE",
             "data/mvar_execution_token_nonces.jsonl",
@@ -388,6 +389,73 @@ class SinkPolicy:
             return []
         return [str(domain).strip().lower() for domain in metadata_domains if str(domain).strip()]
 
+    @staticmethod
+    def _stable_hash(payload: Dict[str, Any]) -> str:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def _requires_execution_contract(self, tool: str, action: str) -> bool:
+        if not self.require_execution_contract:
+            return False
+        return (tool.lower(), action.lower()) in {("bash", "exec"), ("http", "post")}
+
+    def _execution_contract_payload(
+        self,
+        tool: str,
+        action: str,
+        target: str,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        tool_norm = tool.lower()
+        action_norm = action.lower()
+        payload: Dict[str, Any] = {
+            "tool": tool_norm,
+            "action": action_norm,
+            "target": str(target or ""),
+        }
+
+        params = parameters or {}
+        if tool_norm == "bash" and action_norm == "exec":
+            command = str(params.get("command", target or ""))
+            env = params.get("env", {})
+            env_keys = sorted(str(key) for key in env.keys()) if isinstance(env, dict) else []
+            payload.update(
+                {
+                    "command": command,
+                    "env_keys": env_keys,
+                }
+            )
+        elif tool_norm == "http" and action_norm == "post":
+            raw_url = target if "://" in target else f"https://{target}"
+            parsed = urlparse(raw_url)
+            method = str(params.get("method", "POST")).upper()
+            headers = params.get("headers", {})
+            header_keys = sorted(str(key).lower() for key in headers.keys()) if isinstance(headers, dict) else []
+            body = params.get("body", params.get("data"))
+            if body is None:
+                body_hash = ""
+            elif isinstance(body, (bytes, bytearray)):
+                body_hash = hashlib.sha256(bytes(body)).hexdigest()
+            elif isinstance(body, (dict, list)):
+                body_hash = hashlib.sha256(
+                    json.dumps(body, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+                ).hexdigest()
+            else:
+                body_hash = hashlib.sha256(str(body).encode("utf-8")).hexdigest()
+            payload.update(
+                {
+                    "method": method,
+                    "scheme": (parsed.scheme or "https").lower(),
+                    "hostname": (parsed.hostname or "").lower(),
+                    "port": parsed.port or (443 if (parsed.scheme or "https").lower() == "https" else 80),
+                    "path": parsed.path or "/",
+                    "query": parsed.query or "",
+                    "header_keys": header_keys,
+                    "body_hash": body_hash,
+                }
+            )
+        return payload
+
     def _contains_encoded_secret_payload(self, blobs: List[str]) -> bool:
         b64_re = re.compile(r"\b[A-Za-z0-9+/]{24,}={0,2}\b")
         for blob in blobs:
@@ -401,7 +469,14 @@ class SinkPolicy:
                     continue
         return False
 
-    def _issue_execution_token(self, sink: SinkClassification, target: str, provenance_node_id: str, policy_hash: str) -> Optional[Dict[str, Any]]:
+    def _issue_execution_token(
+        self,
+        sink: SinkClassification,
+        target: str,
+        provenance_node_id: str,
+        policy_hash: str,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
         if not self._execution_token_secret:
             if self.fail_closed:
                 return None
@@ -420,6 +495,16 @@ class SinkPolicy:
             "nonce": os.urandom(16).hex(),
             "algorithm": "hmac-sha256",
         }
+        if self._requires_execution_contract(sink.tool, sink.action):
+            payload["contract_version"] = "execution_contract_v1"
+            payload["invocation_hash"] = self._stable_hash(
+                self._execution_contract_payload(
+                    sink.tool,
+                    sink.action,
+                    target,
+                    parameters=parameters,
+                )
+            )
         payload_str = json.dumps(payload, sort_keys=True, separators=(",", ":"))
         payload["signature"] = hmac.new(
             self._execution_token_secret,
@@ -489,6 +574,7 @@ class SinkPolicy:
         target: str,
         provenance_node_id: str,
         policy_hash: str,
+        parameters: Optional[Dict[str, Any]] = None,
     ) -> bool:
         if not token or not self._execution_token_secret:
             return False
@@ -515,6 +601,14 @@ class SinkPolicy:
                 return False
             if token.get("target_hash") != hashlib.sha256(target.encode("utf-8")).hexdigest():
                 return False
+            if self._requires_execution_contract(tool, action):
+                if token.get("contract_version") != "execution_contract_v1":
+                    return False
+                expected_invocation_hash = self._stable_hash(
+                    self._execution_contract_payload(tool, action, target, parameters=parameters)
+                )
+                if token.get("invocation_hash") != expected_invocation_hash:
+                    return False
             signature = token.get("signature", "")
             verify_payload = {k: v for k, v in token.items() if k != "signature"}
             verify_str = json.dumps(verify_payload, sort_keys=True, separators=(",", ":"))
@@ -1159,6 +1253,7 @@ class SinkPolicy:
             capability_granted=capability_granted,
             evaluation_trace=evaluation_trace,
             target=target,
+            parameters=parameters,
             trust_adjusted=trust_adjusted,
             policy_hash=policy_hash
         )
@@ -1214,11 +1309,16 @@ class SinkPolicy:
         token = execution_token
         if token is None and pre_evaluated_decision is not None:
             token = decision.execution_token
-        if self.require_execution_token and decision.outcome in (PolicyOutcome.ALLOW, PolicyOutcome.STEP_UP):
+        contract_required = self._requires_execution_contract(tool, action)
+        if (self.require_execution_token or contract_required) and decision.outcome in (PolicyOutcome.ALLOW, PolicyOutcome.STEP_UP):
             if not token:
                 decision.outcome = PolicyOutcome.BLOCK
-                decision.reason = "Execution token required but missing"
-                decision.evaluation_trace.append("execution_token_required_missing → BLOCK")
+                if contract_required:
+                    decision.reason = "Execution contract required but missing"
+                    decision.evaluation_trace.append("execution_contract_required_missing → BLOCK")
+                else:
+                    decision.reason = "Execution token required but missing"
+                    decision.evaluation_trace.append("execution_token_required_missing → BLOCK")
                 return decision
             if not self.verify_execution_token(
                 token,
@@ -1227,10 +1327,15 @@ class SinkPolicy:
                 target=target,
                 provenance_node_id=provenance_node_id,
                 policy_hash=decision.policy_hash,
+                parameters=parameters,
             ):
                 decision.outcome = PolicyOutcome.BLOCK
-                decision.reason = "Execution token invalid"
-                decision.evaluation_trace.append("execution_token_invalid → BLOCK")
+                if contract_required:
+                    decision.reason = "Execution contract invalid"
+                    decision.evaluation_trace.append("execution_contract_invalid → BLOCK")
+                else:
+                    decision.reason = "Execution token invalid"
+                    decision.evaluation_trace.append("execution_token_invalid → BLOCK")
             else:
                 try:
                     nonce_scroll_id = self._consume_execution_token_nonce(
@@ -1264,6 +1369,7 @@ class SinkPolicy:
         capability_granted: bool,
         evaluation_trace: List[str],
         target: str = "",
+        parameters: Optional[Dict[str, Any]] = None,
         trust_adjusted: bool = False,
         policy_hash: str = ""
     ) -> PolicyDecision:
@@ -1371,6 +1477,7 @@ class SinkPolicy:
                     target=target,
                     provenance_node_id=provenance_node_id,
                     policy_hash=policy_hash,
+                    parameters=parameters,
                 )
                 if self.require_execution_token and execution_token is None:
                     decision.outcome = PolicyOutcome.BLOCK

--- a/mvar/__init__.py
+++ b/mvar/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from mvar_adapters.base import MVARExecutionAdapter
 from mvar_core import __version__
@@ -49,6 +49,25 @@ def _policy_profile_for_record(profile: SecurityProfile) -> str:
     return profile.value
 
 
+def _infer_action(tool_name: str, explicit_action: Optional[str]) -> str:
+    if explicit_action:
+        return explicit_action
+    normalized_tool = tool_name.strip().lower()
+    if normalized_tool in {"bash", "shell", "sh", "zsh", "cmd", "powershell"}:
+        return "exec"
+    if normalized_tool in {"http", "https"}:
+        return "post"
+    return "execute"
+
+
+def _default_target_extractor(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> str:
+    if args:
+        return str(args[0])
+    if "target" in kwargs:
+        return str(kwargs["target"])
+    return "unknown"
+
+
 def _to_decision_record(decision: Any, profile: SecurityProfile) -> Dict[str, Any]:
     raw = decision.to_dict()
     return {
@@ -90,6 +109,8 @@ def protect(
     profile: str = "balanced",
     trusted: bool = False,
     tool_name: Optional[str] = None,
+    action: Optional[str] = None,
+    target_extractor: Optional[Callable[[Tuple[Any, ...], Dict[str, Any]], str]] = None,
 ) -> Callable:
     """Wrap a tool callable with MVAR policy enforcement.
 
@@ -110,6 +131,8 @@ def protect(
     adapter = MVARExecutionAdapter(policy, graph)
 
     resolved_tool_name = tool_name or getattr(tool_fn, "__name__", "tool")
+    resolved_action = _infer_action(resolved_tool_name, action)
+    resolved_target_extractor = target_extractor or _default_target_extractor
     if trusted:
         provenance_node_id = adapter.create_user_provenance(resolved_tool_name)
     else:
@@ -120,14 +143,23 @@ def protect(
 
     @wraps(tool_fn)
     def _wrapped(*args: Any, **kwargs: Any) -> Any:
-        # v1 heuristic: derive target from first positional argument; expose
-        # explicit metadata overrides in a future version.
-        target = str(args[0]) if args else "unknown"
-        decision = adapter.authorize_execution(
+        target = resolved_target_extractor(args, kwargs)
+        parameters = dict(kwargs) if kwargs else None
+        pre_decision = adapter.evaluate(
             tool=resolved_tool_name,
-            action="execute",
+            action=resolved_action,
             target=target,
             provenance_node_id=provenance_node_id,
+            parameters=parameters,
+        )
+        decision = adapter.authorize_execution(
+            tool=resolved_tool_name,
+            action=resolved_action,
+            target=target,
+            provenance_node_id=provenance_node_id,
+            parameters=parameters,
+            execution_token=getattr(pre_decision, "execution_token", None),
+            pre_evaluated_decision=pre_decision,
         )
         decision_record = _to_decision_record(decision, mapped_profile)
 

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -1,0 +1,236 @@
+"""Execution-contract regression tests for privileged sink invocations."""
+
+import os
+
+import test_common  # noqa: F401
+from capability import CapabilityGrant, CapabilityRuntime, CapabilityType, build_shell_tool
+from provenance import ProvenanceGraph, provenance_user_input
+from sink_policy import PolicyOutcome, SinkPolicy, register_common_sinks
+
+
+_ENV_KEYS = (
+    "MVAR_REQUIRE_EXECUTION_CONTRACT",
+    "MVAR_REQUIRE_EXECUTION_TOKEN",
+    "MVAR_EXECUTION_TOKEN_ONE_TIME",
+    "MVAR_EXEC_TOKEN_SECRET",
+    "MVAR_FAIL_CLOSED",
+    "MVAR_REQUIRE_SIGNED_POLICY_BUNDLE",
+)
+
+
+def _snapshot_env():
+    return {key: os.environ.get(key) for key in _ENV_KEYS}
+
+
+def _restore_env(snapshot):
+    for key, value in snapshot.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _configure_contract_env():
+    os.environ["MVAR_REQUIRE_EXECUTION_CONTRACT"] = "1"
+    os.environ["MVAR_REQUIRE_EXECUTION_TOKEN"] = "0"
+    os.environ["MVAR_EXECUTION_TOKEN_ONE_TIME"] = "1"
+    os.environ["MVAR_EXEC_TOKEN_SECRET"] = "execution_contract_secret"
+    os.environ["MVAR_FAIL_CLOSED"] = "1"
+    os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] = "0"
+
+
+def test_execution_contract_missing_blocks_bash_exec():
+    snap = _snapshot_env()
+    try:
+        _configure_contract_env()
+        graph = ProvenanceGraph(enable_qseal=False)
+        runtime = CapabilityRuntime()
+        runtime.manifests["bash"] = build_shell_tool("bash", ["ls", "echo"], ["/tmp/**"])
+        policy = SinkPolicy(runtime, graph, enable_qseal=False)
+        register_common_sinks(policy)
+        node = provenance_user_input(graph, "list tmp")
+
+        decision = policy.evaluate(
+            tool="bash",
+            action="exec",
+            target="ls",
+            provenance_node_id=node.node_id,
+            parameters={"command": "ls /tmp"},
+        )
+
+        blocked = policy.authorize_execution(
+            tool="bash",
+            action="exec",
+            target="ls",
+            provenance_node_id=node.node_id,
+            parameters={"command": "ls /tmp"},
+            execution_token=None,
+        )
+        assert blocked.outcome == PolicyOutcome.BLOCK
+        assert "execution contract required" in blocked.reason.lower()
+    finally:
+        _restore_env(snap)
+
+
+def test_execution_contract_detects_bash_argument_mutation():
+    snap = _snapshot_env()
+    try:
+        _configure_contract_env()
+        graph = ProvenanceGraph(enable_qseal=False)
+        runtime = CapabilityRuntime()
+        runtime.manifests["bash"] = build_shell_tool("bash", ["ls", "echo"], ["/tmp/**"])
+        policy = SinkPolicy(runtime, graph, enable_qseal=False)
+        register_common_sinks(policy)
+        node = provenance_user_input(graph, "list tmp")
+
+        decision = policy.evaluate(
+            tool="bash",
+            action="exec",
+            target="ls",
+            provenance_node_id=node.node_id,
+            parameters={"command": "ls /tmp"},
+        )
+        assert decision.execution_token is not None
+
+        blocked = policy.authorize_execution(
+            tool="bash",
+            action="exec",
+            target="ls",
+            provenance_node_id=node.node_id,
+            parameters={"command": "echo /tmp"},
+            execution_token=decision.execution_token,
+            pre_evaluated_decision=decision,
+        )
+        assert blocked.outcome == PolicyOutcome.BLOCK
+        assert "execution contract invalid" in blocked.reason.lower()
+        assert any("execution_contract_invalid" in line for line in blocked.evaluation_trace)
+    finally:
+        _restore_env(snap)
+
+
+def test_execution_contract_detects_http_invocation_mutation():
+    snap = _snapshot_env()
+    try:
+        _configure_contract_env()
+        graph = ProvenanceGraph(enable_qseal=False)
+        runtime = CapabilityRuntime()
+        runtime.register_tool(
+            "http",
+            capabilities=[
+                CapabilityGrant(
+                    cap_type=CapabilityType.NETWORK_EGRESS,
+                    allowed_targets=["*"],
+                )
+            ],
+        )
+        policy = SinkPolicy(runtime, graph, enable_qseal=False)
+        register_common_sinks(policy)
+        node = provenance_user_input(graph, "upload status")
+
+        decision = policy.evaluate(
+            tool="http",
+            action="post",
+            target="https://api.example.com/upload",
+            provenance_node_id=node.node_id,
+            parameters={"method": "POST", "body": {"status": "ok"}},
+        )
+        assert decision.execution_token is not None
+
+        blocked = policy.authorize_execution(
+            tool="http",
+            action="post",
+            target="https://api.example.com/upload",
+            provenance_node_id=node.node_id,
+            parameters={"method": "GET", "body": {"status": "ok"}},
+            execution_token=decision.execution_token,
+            pre_evaluated_decision=decision,
+        )
+        assert blocked.outcome == PolicyOutcome.BLOCK
+        assert "execution contract invalid" in blocked.reason.lower()
+    finally:
+        _restore_env(snap)
+
+
+def test_execution_contract_replay_is_blocked():
+    snap = _snapshot_env()
+    try:
+        _configure_contract_env()
+        graph = ProvenanceGraph(enable_qseal=False)
+        runtime = CapabilityRuntime()
+        runtime.register_tool(
+            "http",
+            capabilities=[
+                CapabilityGrant(
+                    cap_type=CapabilityType.NETWORK_EGRESS,
+                    allowed_targets=["*"],
+                )
+            ],
+        )
+        policy = SinkPolicy(runtime, graph, enable_qseal=False)
+        register_common_sinks(policy)
+        node = provenance_user_input(graph, "upload status")
+
+        decision = policy.evaluate(
+            tool="http",
+            action="post",
+            target="https://api.example.com/upload",
+            provenance_node_id=node.node_id,
+            parameters={"method": "POST", "body": {"status": "ok"}},
+        )
+        assert decision.execution_token is not None
+
+        first = policy.authorize_execution(
+            tool="http",
+            action="post",
+            target="https://api.example.com/upload",
+            provenance_node_id=node.node_id,
+            parameters={"method": "POST", "body": {"status": "ok"}},
+            execution_token=decision.execution_token,
+            pre_evaluated_decision=decision,
+        )
+        assert first.outcome == PolicyOutcome.ALLOW
+
+        replay = policy.authorize_execution(
+            tool="http",
+            action="post",
+            target="https://api.example.com/upload",
+            provenance_node_id=node.node_id,
+            parameters={"method": "POST", "body": {"status": "ok"}},
+            execution_token=decision.execution_token,
+            pre_evaluated_decision=decision,
+        )
+        assert replay.outcome == PolicyOutcome.BLOCK
+        assert "execution contract invalid" in replay.reason.lower()
+    finally:
+        _restore_env(snap)
+
+
+def test_execution_contract_not_required_for_filesystem_read():
+    snap = _snapshot_env()
+    try:
+        _configure_contract_env()
+        graph = ProvenanceGraph(enable_qseal=False)
+        runtime = CapabilityRuntime()
+        runtime.register_tool(
+            "filesystem",
+            capabilities=[
+                CapabilityGrant(
+                    cap_type=CapabilityType.FILESYSTEM_READ,
+                    allowed_targets=["/tmp/**", "/private/tmp/**"],
+                )
+            ],
+        )
+        policy = SinkPolicy(runtime, graph, enable_qseal=False)
+        register_common_sinks(policy)
+        node = provenance_user_input(graph, "read file")
+
+        decision = policy.authorize_execution(
+            tool="filesystem",
+            action="read",
+            target="/tmp/report.txt",
+            provenance_node_id=node.node_id,
+            execution_token=None,
+        )
+        assert decision.outcome == PolicyOutcome.ALLOW
+    finally:
+        _restore_env(snap)

--- a/tests/test_protect.py
+++ b/tests/test_protect.py
@@ -24,6 +24,7 @@ class _FakeDecision:
         self._reason = reason
         self._integrity = integrity
         self._risk = risk
+        self.execution_token = {"token": "unit-test-token"}
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -72,6 +73,30 @@ def _install_fake_runtime(
             captured["untrusted_provenance_source"] = source
             return "untrusted-node"
 
+        def evaluate(
+            self,
+            tool: str,
+            action: str,
+            target: str,
+            provenance_node_id: str,
+            parameters: Dict[str, Any] | None = None,
+        ) -> _FakeDecision:
+            captured.setdefault("evaluate_calls", []).append(
+                {
+                    "tool": tool,
+                    "action": action,
+                    "target": target,
+                    "provenance_node_id": provenance_node_id,
+                    "parameters": parameters,
+                }
+            )
+            return _FakeDecision(
+                outcome=outcome,
+                reason=reason,
+                integrity=integrity,
+                risk=risk,
+            )
+
         def authorize_execution(
             self,
             tool: str,
@@ -88,6 +113,9 @@ def _install_fake_runtime(
                     "action": action,
                     "target": target,
                     "provenance_node_id": provenance_node_id,
+                    "parameters": parameters,
+                    "execution_token": execution_token,
+                    "pre_evaluated_decision": pre_evaluated_decision,
                 }
             )
             return _FakeDecision(
@@ -264,3 +292,38 @@ def test_protect_called_twice_same_wrapper(monkeypatch: pytest.MonkeyPatch) -> N
     assert calls["count"] == 2
     assert len(captured["calls"]) == 2
     assert captured["calls"][0]["provenance_node_id"] == captured["calls"][1]["provenance_node_id"]
+
+
+def test_protect_infers_bash_exec_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _install_fake_runtime(monkeypatch, outcome="allow")
+
+    def tool(command: str) -> str:
+        return command
+
+    wrapped = protect(tool, tool_name="bash")
+    assert wrapped("ls /tmp") == "ls /tmp"
+    assert captured["calls"][-1]["action"] == "exec"
+
+
+def test_protect_infers_http_post_action(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _install_fake_runtime(monkeypatch, outcome="allow")
+
+    def tool(target: str, **kwargs: Any) -> str:
+        return target
+
+    wrapped = protect(tool, tool_name="http")
+    assert wrapped("https://api.example.com/upload", method="POST") == "https://api.example.com/upload"
+    assert captured["calls"][-1]["action"] == "post"
+
+
+def test_protect_passes_pre_evaluated_decision_and_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _install_fake_runtime(monkeypatch, outcome="allow")
+
+    def tool(command: str, *, dry_run: bool = False) -> str:
+        assert dry_run is True
+        return command
+
+    wrapped = protect(tool, tool_name="bash")
+    assert wrapped("echo hello", dry_run=True) == "echo hello"
+    assert captured["calls"][-1]["pre_evaluated_decision"] is not None
+    assert captured["calls"][-1]["execution_token"] == {"token": "unit-test-token"}

--- a/tests/test_security_profiles.py
+++ b/tests/test_security_profiles.py
@@ -11,6 +11,7 @@ from sink_policy import PolicyOutcome
 _PROFILE_KEYS = {
     "MVAR_FAIL_CLOSED",
     "MVAR_ENFORCE_ED25519",
+    "MVAR_REQUIRE_EXECUTION_CONTRACT",
     "MVAR_HTTP_DEFAULT_DENY",
     "MVAR_REQUIRE_EXECUTION_TOKEN",
     "MVAR_EXECUTION_TOKEN_ONE_TIME",
@@ -40,6 +41,7 @@ def test_profile_summary_contains_expected_keys():
     assert summary["MVAR_ENABLE_COMPOSITION_RISK"] == "1"
     assert summary["MVAR_ENFORCE_ED25519"] == "1"
     assert summary["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] == "1"
+    assert summary["MVAR_REQUIRE_EXECUTION_CONTRACT"] == "1"
     assert summary["MVAR_HTTP_DEFAULT_DENY"] == "1"
 
 
@@ -50,6 +52,7 @@ def test_apply_profile_balanced_sets_core_hardening():
         assert os.environ["MVAR_REQUIRE_EXECUTION_TOKEN"] == "1"
         assert os.environ["MVAR_ENABLE_COMPOSITION_RISK"] == "1"
         assert os.environ["MVAR_EXECUTION_TOKEN_NONCE_PERSIST"] == "0"
+        assert os.environ["MVAR_REQUIRE_EXECUTION_CONTRACT"] == "0"
         assert os.environ["MVAR_HTTP_DEFAULT_DENY"] == "0"
     finally:
         _restore_env(snap)
@@ -61,6 +64,7 @@ def test_apply_profile_strict_enables_enterprise_roots():
         apply_profile(SecurityProfile.STRICT)
         assert os.environ["MVAR_ENFORCE_ED25519"] == "1"
         assert os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] == "1"
+        assert os.environ["MVAR_REQUIRE_EXECUTION_CONTRACT"] == "1"
         assert os.environ["MVAR_HTTP_DEFAULT_DENY"] == "1"
     finally:
         _restore_env(snap)


### PR DESCRIPTION
## What this changes

- Requires verified execution contracts for privileged sink calls:
  - `bash.exec`
  - `http.post`
- Binds authorization to invocation details via deterministic invocation hash.
- Blocks execution when:
  - contract missing
  - contract invalid
  - invocation mutated after decision
  - replayed token/contract reuse
- Keeps non-privileged sinks unaffected by contract requirement.
- Updates `protect()` to pre-evaluate + authorize with decision token and inferred action mapping.

## Why

Wrapper-level authorization alone can still leave room for decision/execution drift.
This patch hard-binds privileged authorization to the exact invocation at execution time.

## Security impact

- Reduces TOCTOU-style mutation risk between policy decision and sink execution.
- Strengthens replay resistance for privileged calls.
- Tightens sink-bound determinism for HTTP egress and shell execution paths.

## Validation

- Full test suite passing: `294 passed`
- New regression suite:
  - `tests/test_execution_contracts.py`
- Updated regression coverage:
  - `tests/test_protect.py`
  - `tests/test_security_profiles.py`

## Scope

Limited to execution-contract enforcement for `bash.exec` and `http.post`,
plus wrapper integration and tests. No broad API break.
