### PR TITLE
release: prepare v1.4.0 metadata and notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to MVAR are documented in `docs/releases/`.
 
+## v1.4.0
+
+- Verified execution contracts for privileged sink calls (`bash.exec`, `http.post`):
+  - invocation hash binding between authorization and exact runtime invocation
+  - fail-closed block behavior for missing/invalid/mutated/replayed contracts
+- Strict-profile HTTP egress hardening:
+  - default deny unless explicitly allowlisted
+  - actionable failure path when allowlist is missing in strict mode
+
+Full release notes: [docs/releases/v1.4.0.md](docs/releases/v1.4.0.md)
+
 ## v1.3.0
 
 - Strict-mode enterprise hardening:

--- a/docs/releases/UNRELEASED.md
+++ b/docs/releases/UNRELEASED.md
@@ -1,9 +1,11 @@
 # Unreleased
 
-## Post-v1.3.0
+## Post-v1.4.0
 
-- Release `v1.3.0` cut with strict-mode enterprise hardening.
-- See [v1.3.0 release notes](./v1.3.0.md) for shipped changes.
+- Release `v1.4.0` cut with verified execution contracts and strict egress hardening.
+- See [v1.4.0 release notes](./v1.4.0.md) for shipped changes.
+
+## Historical backlog (pre-v1.4.0)
 
 ## Maintainer and Adoption Hygiene
 

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,0 +1,37 @@
+# MVAR v1.4.0 — Verified Execution Contracts
+
+## Validation Snapshot
+
+- Launch gate: PASS
+- Attack corpus: 50/50 blocked
+- Full suite: 294 passing
+
+## New
+
+- Verified execution contracts required for privileged sink calls:
+  - `bash.exec`
+  - `http.post`
+- Invocation hash binding ties authorization to exact target and normalized invocation parameters at execution time.
+- Execution is blocked when contract evidence is:
+  - missing
+  - invalid
+  - mutated between decision and execution
+  - replayed
+
+## Hardened
+
+- Strict profile now enforces default-deny HTTP egress unless explicitly allowlisted.
+- Clear fail-closed errors when strict egress allowlist is required but not configured.
+- `protect()` now runs pre-evaluate + authorize flow with token handoff to reduce policy-to-execution drift.
+
+## Security Impact
+
+- Closes TOCTOU-style drift between policy decision and sink execution.
+- Hard-binds privileged authorization to exact invocation semantics at runtime.
+- Strengthens replay resistance for contracted sink calls.
+
+## Baseline Included from v1.3.0
+
+- Ed25519-only strict mode.
+- Signed policy bundle enforcement in strict mode.
+- Fail-closed strict startup behavior for missing/invalid policy prerequisites.

--- a/mvar-core/__init__.py
+++ b/mvar-core/__init__.py
@@ -1,5 +1,5 @@
 # MVAR Core - Information Flow Control for AI Agents
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 try:
     from .profiles import SecurityProfile, apply_profile, create_default_runtime, profile_summary

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = readme_file.read_text(encoding="utf-8") if readme_file.exists
 
 setup(
     name="mvar",
-    version="1.3.0",
+    version="1.4.0",
     author="Shawn Cohen",
     author_email="security@mvar.io",
     description="MVAR: Information Flow Control for LLM Agent Runtimes — Deterministic prompt injection defense via dual-lattice IFC with cryptographic provenance",


### PR DESCRIPTION
## What this changes

- Bumps package/runtime version to `1.4.0`.
- Adds release notes: `docs/releases/v1.4.0.md`.
- Updates top-level changelog with `v1.4.0` entry.
- Advances `docs/releases/UNRELEASED.md` to post-`v1.4.0` state.

## Why

PR #52 (verified execution contracts) is merged on `main`, but the repository
version metadata still reported `1.3.0`. This release-prep commit aligns
version metadata and release docs before tagging.

## Validation

- `python scripts/check_release_integrity.py` -> PASS (`1.4.0`)
- `pytest -q tests/test_security_profiles.py tests/test_execution_contracts.py` -> PASS

## Scope

Release metadata/docs only. No runtime behavior changes.
