### PR TITLE
test/docs: freeze adapter bridge contract surface

### DIFF
--- a/docs/ADAPTER_SPEC.md
+++ b/docs/ADAPTER_SPEC.md
@@ -81,3 +81,28 @@ Pass criteria:
 
 - First-party adapters MUST pass conformance harness in CI before release.
 - Third-party adapters SHOULD publish harness results and MVAR version compatibility.
+
+## Governor bridge compatibility surface (v1 freeze)
+
+This section defines the v1 compatibility surface consumed by the MIRRA Execution Governor bridge.
+
+Required adapter entrypoint:
+- `MVARExecutionAdapter.authorize_execution(tool, action, target, provenance_node_id, parameters=None, execution_token=None, pre_evaluated_decision=None)`
+
+Required decision fields (via `PolicyDecision.to_dict()`):
+- `outcome` (`allow|block|step_up`)
+- `reason`
+- `evaluation_trace` (list)
+- `policy_hash`
+- `target_hash`
+- `sink.tool`
+- `sink.action`
+- `sink.risk`
+- `provenance.node_id`
+- `provenance.integrity`
+- `provenance.confidentiality`
+
+Contract policy:
+- v1.x releases MUST preserve the method name and parameter order above.
+- v1.x releases MUST preserve decision fields above.
+- Any breaking change requires a major-version bump and explicit migration guidance.

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -2,9 +2,16 @@
 
 import inspect
 
+from mvar_adapters.base import MVARExecutionAdapter
 from mvar_core.capability import CapabilityRuntime, build_shell_tool
 from mvar_core.provenance import ProvenanceGraph, provenance_user_input
-from mvar_core.sink_policy import PolicyOutcome, SinkPolicy, register_common_sinks
+from mvar_core.sink_policy import (
+    PolicyOutcome,
+    SinkClassification,
+    SinkPolicy,
+    SinkRisk,
+    register_common_sinks,
+)
 
 
 def test_core_public_symbols_exist():
@@ -50,3 +57,94 @@ def test_quickstart_flow_contract_runs_without_api_errors():
 
     assert decision.outcome in {PolicyOutcome.ALLOW, PolicyOutcome.STEP_UP, PolicyOutcome.BLOCK}
     assert decision.reason
+
+
+def test_mvar_execution_adapter_authorize_signature_is_stable():
+    sig = inspect.signature(MVARExecutionAdapter.authorize_execution)
+    params = list(sig.parameters)
+    assert params == [
+        "self",
+        "tool",
+        "action",
+        "target",
+        "provenance_node_id",
+        "parameters",
+        "execution_token",
+        "pre_evaluated_decision",
+    ]
+
+
+def test_mvar_execution_adapter_enforce_signature_is_stable():
+    sig = inspect.signature(MVARExecutionAdapter.enforce_and_execute)
+    params = list(sig.parameters)
+    assert params == [
+        "self",
+        "tool",
+        "action",
+        "target",
+        "execute_fn",
+        "provenance_node_id",
+        "source_text",
+        "source_is_untrusted",
+        "parameters",
+        "execution_token",
+        "target_is_fallback",
+    ]
+
+
+def test_governor_bridge_decision_shape_contract(monkeypatch):
+    # Contract freeze: keep token requirements off for deterministic shape checks.
+    monkeypatch.setenv("MVAR_REQUIRE_EXECUTION_TOKEN", "0")
+    monkeypatch.setenv("MVAR_FAIL_CLOSED", "1")
+    monkeypatch.setenv("MVAR_ENABLE_LEDGER", "0")
+    monkeypatch.setenv("MVAR_ENABLE_TRUST_ORACLE", "0")
+
+    graph = ProvenanceGraph(enable_qseal=False)
+    runtime = CapabilityRuntime()
+    runtime.manifests["demo_tool"] = build_shell_tool(
+        tool_name="demo_tool",
+        allowed_commands=["echo"],
+        allowed_paths=["/tmp/**"],
+    )
+
+    policy = SinkPolicy(runtime, graph, enable_qseal=False)
+    register_common_sinks(policy)
+    policy.register_sink(
+        SinkClassification(
+            tool="demo_tool",
+            action="exec",
+            risk=SinkRisk.LOW,
+            rationale="contract test sink",
+            require_capability=runtime.manifests["demo_tool"].capabilities[0].cap_type,
+            block_untrusted_integrity=False,
+        )
+    )
+    adapter = MVARExecutionAdapter(policy=policy, provenance_graph=graph, strict=False)
+
+    node_id = adapter.create_user_provenance("contract check")
+    decision = adapter.authorize_execution(
+        tool="demo_tool",
+        action="exec",
+        target="echo",
+        provenance_node_id=node_id,
+        parameters={"command": "echo ok"},
+    )
+
+    raw = decision.to_dict()
+    normalized_outcome = str(raw.get("outcome", "")).lower()
+
+    assert normalized_outcome in {"allow", "block", "step_up"}
+    assert isinstance(raw.get("reason"), str) and raw.get("reason")
+    assert isinstance(raw.get("evaluation_trace"), list)
+    assert isinstance(raw.get("policy_hash"), str) and raw.get("policy_hash")
+    assert isinstance(raw.get("target_hash"), str) and raw.get("target_hash")
+
+    sink = raw.get("sink", {})
+    assert sink.get("tool")
+    assert sink.get("action")
+    assert sink.get("risk")
+
+    prov = raw.get("provenance", {})
+    assert prov.get("node_id")
+    assert prov.get("integrity")
+    assert prov.get("confidentiality")


### PR DESCRIPTION
## What this changes
- Adds explicit v1 Governor bridge compatibility section to `docs/ADAPTER_SPEC.md`.
- Adds CI-enforced contract tests in `tests/test_api_contracts.py` for:
  - adapter entrypoint signature stability
  - `enforce_and_execute` signature stability
  - governor-consumed decision dictionary shape stability

## Scope boundary
This PR is intentionally limited to:
- `docs/ADAPTER_SPEC.md`
- `tests/test_api_contracts.py`

No runtime authorization-flow changes. No execution-contract changes. No witness/proof-pack/version/release modifications.

## Frozen contract assumptions (v1)
- `MVARExecutionAdapter.authorize_execution` parameters remain:
  `tool, action, target, provenance_node_id, parameters, execution_token, pre_evaluated_decision`
- `MVARExecutionAdapter.enforce_and_execute` parameters remain:
  `tool, action, target, execute_fn, provenance_node_id, source_text, source_is_untrusted, parameters, execution_token, target_is_fallback`
- `PolicyDecision.to_dict()` must preserve governor-consumed fields:
  - `outcome`, `reason`, `evaluation_trace`, `policy_hash`, `target_hash`
  - `sink.tool`, `sink.action`, `sink.risk`
  - `provenance.node_id`, `provenance.integrity`, `provenance.confidentiality`

## Validation
- `pytest -q tests/test_api_contracts.py`
- Result: `6 passed`
