### PR TITLE
docs: normalize contribution path to root CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: mailto:security@mvar.io
     about: Report vulnerabilities privately. Do not post exploit details in public issues.
   - name: Contribution guide
-    url: https://github.com/mvar-security/mvar/blob/main/docs/BUILD_WITH_US.md
+    url: https://github.com/mvar-security/mvar/blob/main/CONTRIBUTING.md
     about: Read contribution expectations and security invariants before opening issues/PRs.
   - name: Integration playbook
     url: https://github.com/mvar-security/mvar/blob/main/docs/AGENT_INTEGRATION_PLAYBOOK.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,10 +60,10 @@ Open source makes MVAR better. Structured governance keeps it secure.
 ### Get Started
 
 - **GitHub:** https://github.com/mvar-security/mvar
-- **Docs:** [README.md](../README.md)
-- **Adapter Contract:** [ADAPTER_SPEC.md](ADAPTER_SPEC.md)
-- **First-Party Wrappers:** [FIRST_PARTY_ADAPTERS.md](FIRST_PARTY_ADAPTERS.md)
-- **Security Policy:** [SECURITY.md](../SECURITY.md)
+- **Docs:** [README.md](README.md)
+- **Adapter Contract:** [ADAPTER_SPEC.md](docs/ADAPTER_SPEC.md)
+- **First-Party Wrappers:** [FIRST_PARTY_ADAPTERS.md](docs/FIRST_PARTY_ADAPTERS.md)
+- **Security Policy:** [SECURITY.md](SECURITY.md)
 
 ### Contact
 

--- a/README.md
+++ b/README.md
@@ -261,13 +261,13 @@ This README is intentionally front-loaded for fast evaluation. Detailed material
 
 - Run validation: `bash scripts/launch-gate.sh`
 - Submit adversarial vectors: [docs/ATTACK_VECTOR_SUBMISSIONS.md](docs/ATTACK_VECTOR_SUBMISSIONS.md)
-- Build adapters and integrations: [docs/BUILD_WITH_US.md](docs/BUILD_WITH_US.md)
+- Build adapters and integrations: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Use the pinned 30-second proof post: [docs/outreach/GITHUB_PINNED_POST_30S_PROOF.md](docs/outreach/GITHUB_PINNED_POST_30S_PROOF.md)
 
 ## Contributing
 
 **MVAR is open source by design.** We welcome adapter integrations, security hardening, tests, and documentation improvements that preserve security invariants.
-See [docs/BUILD_WITH_US.md](docs/BUILD_WITH_US.md) for contribution lanes, requirements, conformance expectations, and security reporting workflow.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution lanes, requirements, conformance expectations, and security reporting workflow.
 
 ---
 


### PR DESCRIPTION
## Scope
Contrib path normalization only.

## Changes
- Renamed `docs/BUILD_WITH_US.md` to root `CONTRIBUTING.md`.
- Updated README contribution links to `CONTRIBUTING.md`.
- Updated `.github/ISSUE_TEMPLATE/config.yml` contact link to `CONTRIBUTING.md`.

## Hard Scope Confirmation
- No runtime code changes
- No test changes
- No workflow logic changes
- No packaging/version/release changes

## Notes
- Contribution guide content is preserved; only path/link updates were made.
- Minimal link fixes were applied inside `CONTRIBUTING.md` due file relocation.
