### PR TITLE
docs: add canonical RUN_THE_PROOF operator runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Invariant: `UNTRUSTED input + CRITICAL sink -> BLOCK`
 ## Try It In 30 Seconds
 
 [30-Second Proof](#30-second-proof) · [Quick Start](#quick-start) · [Governed MCP Proof](docs/outreach/GOVERNED_MCP_RUNTIME_PROOF.md) · [Adapters](docs/FIRST_PARTY_ADAPTERS.md)
+Canonical proof runbook: [RUN_THE_PROOF.md](RUN_THE_PROOF.md)
 
 [![Launch Gate](https://github.com/mvar-security/mvar/actions/workflows/launch-gate.yml/badge.svg)](https://github.com/mvar-security/mvar/actions/workflows/launch-gate.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mvar-security/mvar/badge)](https://scorecard.dev/viewer/?uri=github.com/mvar-security/mvar)

--- a/RUN_THE_PROOF.md
+++ b/RUN_THE_PROOF.md
@@ -1,0 +1,58 @@
+# Run The Proof
+
+Canonical operator runbook to verify MVAR in under 2 minutes.
+
+## Quick Proof (2 minutes)
+
+### Step 1 — Clone
+```bash
+git clone https://github.com/mvar-security/mvar
+cd mvar
+```
+
+### Step 2 — Run proof pack
+```bash
+scripts/repro-validation-pack.sh
+```
+
+### Step 3 — Verify witness chain
+```bash
+mvar-verify-witness data/mvar_decisions.jsonl --require-chain
+```
+
+### Step 4 — Inspect artifacts
+Expected artifact locations:
+
+```text
+artifacts/
+artifacts/latest/
+artifacts/<timestamp>/
+```
+
+### Step 5 — Confirm PASS signals
+Expected output signals:
+
+```text
+launch gate PASS
+attack corpus blocked
+witness verification PASS
+```
+
+## What the proof pack validates
+
+- Launch gate executes and reports PASS.
+- Attack corpus execution is blocked under enforced policy.
+- Validation summary is emitted in deterministic machine-readable form.
+- Witness output is present for chain verification.
+
+## Artifact structure
+
+- `artifacts/latest/`: pointer to the most recent proof output.
+- `artifacts/<timestamp>/`: immutable run-specific proof artifacts.
+- `artifacts/`: parent directory holding current and historical proof outputs.
+
+## Witness verification explanation
+
+`mvar-verify-witness` validates signed witness records and, with `--require-chain`, verifies previous-signature linkage.
+
+Pass means the witness file is structurally valid, signatures verify, and the chain integrity check succeeds.


### PR DESCRIPTION
## Scope
Canonical proof surface only.

## Changes
- Added `RUN_THE_PROOF.md` as the operator-focused 2-minute verification runbook.
- Added one README link to `RUN_THE_PROOF.md`.

## Required flow included
1. Clone
2. Run `scripts/repro-validation-pack.sh`
3. Verify witness chain (`mvar-verify-witness ... --require-chain`)
4. Inspect artifact locations
5. Confirm explicit PASS signals

## Hard Scope Confirmation
- Docs only
- No runtime changes
- No tests/workflows/packaging changes
- No architecture or API changes
