### PR TITLE
ci/docs: add PyPI package-check and trusted publish lane

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -1,0 +1,38 @@
+name: Package Check
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  package-check:
+    name: Build + Twine + Install Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install packaging tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Twine metadata check
+        run: twine check dist/*
+
+      - name: Wheel install verification
+        run: python -m pip install dist/*.whl

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,34 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build and publish release to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/releases/PYPI_RELEASE.md
+++ b/docs/releases/PYPI_RELEASE.md
@@ -1,0 +1,31 @@
+# PyPI Release Runbook
+
+This runbook documents trusted publishing for `mvar` and the tag-based publish flow.
+
+## Setup Trusted Publisher
+
+Configure a trusted publisher in PyPI with these exact fields:
+
+- PyPI project name: `mvar`
+- GitHub repository: `mvar-security/mvar`
+- Workflow filename: `pypi-publish.yml`
+- Environment name: `pypi`
+
+## Release Steps
+
+1. Ensure `main` is green and the intended release commit is merged.
+2. Create and push a release tag:
+
+```bash
+git tag vX.X.X
+git push origin vX.X.X
+```
+
+3. Tag push triggers `.github/workflows/pypi-publish.yml` and uploads package artifacts to PyPI via OIDC trusted publishing.
+
+## Post-publish verification
+
+```bash
+pip install mvar==<version>
+python -c "from mvar import protect; print('install verified')"
+```


### PR DESCRIPTION
## Scope
PyPI publication lane only.

## Changes
- Added `.github/workflows/package-check.yml`:
  - `python -m build`
  - `twine check dist/*`
  - `pip install dist/*.whl`
- Added `.github/workflows/pypi-publish.yml`:
  - tag-triggered (`v*`)
  - trusted publishing via OIDC (`id-token: write`)
  - environment `pypi`
- Added `docs/releases/PYPI_RELEASE.md` runbook with exact trusted-publisher fields and release verification commands.

## Hard Scope Confirmation
- No runtime code changes
- No test changes
- No version bump
- No packaging behavior changes outside publish/check lane
