### PR TITLE
release: version parity correction to 1.4.2

### DIFF
--- a/mvar-core/__init__.py
+++ b/mvar-core/__init__.py
@@ -1,5 +1,5 @@
 # MVAR Core - Information Flow Control for AI Agents
-__version__ = "1.4.0"
+__version__ = "1.4.2"
 
 try:
     from .profiles import SecurityProfile, apply_profile, create_default_runtime, profile_summary

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ long_description = readme_file.read_text(encoding="utf-8") if readme_file.exists
 
 setup(
     name="mvar-security",
-    version="1.4.0",
+    version="1.4.2",
     author="Shawn Cohen",
     author_email="security@mvar.io",
     description="MVAR: Information Flow Control for LLM Agent Runtimes — Deterministic prompt injection defense via dual-lattice IFC with cryptographic provenance",


### PR DESCRIPTION
## Goal
Forward-only version parity correction after successful PyPI lane bring-up.

## Scope
Version metadata only.

## Files changed
- `setup.py`:
  - `version="1.4.0"` -> `version="1.4.2"`
- `mvar-core/__init__.py`:
  - `__version__ = "1.4.0"` -> `__version__ = "1.4.2"`

## Explicitly unchanged
- Runtime logic
- Tests and test behavior
- Workflow logic
- README and proof docs
- Release mechanics beyond version-field alignment

## Note
PyPI distribution name remains `mvar-security`, while Python import path remains `from mvar import protect`.

## Validation
- `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13 -m build --no-isolation`
- `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13 -m twine check dist/*`
- `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13 -c "import mvar, mvar_core; print(mvar.__version__, mvar_core.__version__)"`
