### PR TITLE
fix: truthful QSEAL signing labels with Ed25519 default

### DIFF
--- a/mvar-core/cli_ledger.py
+++ b/mvar-core/cli_ledger.py
@@ -12,7 +12,6 @@ Commands:
 
 Usage:
     export MVAR_ENABLE_LEDGER=1
-    export QSEAL_SECRET=$(openssl rand -hex 32)
 
     # Run agent, generate some BLOCK decisions
     # ...
@@ -57,7 +56,7 @@ def _init_ledger_or_exit() -> Any:
         return MVARDecisionLedger()
     except Exception as exc:
         print(f"❌ Unable to initialize decision ledger: {exc}")
-        print("Tip: set QSEAL_SECRET when MVAR_ENABLE_LEDGER=1")
+        print("Tip: ensure Ed25519 is available; for legacy HMAC verification, set QSEAL_SECRET")
         raise SystemExit(1)
 
 
@@ -86,7 +85,7 @@ def mvar_report():
             print("No verified decisions available.")
             print()
             print("Possible cause: signature verification mismatch.")
-            print("If running HMAC fallback mode, ensure QSEAL_SECRET matches the value")
+            print("If verifying legacy HMAC fallback entries, ensure QSEAL_SECRET matches the value")
             print("used when decisions were recorded.")
         else:
             print("No decisions recorded yet.")
@@ -451,7 +450,7 @@ _VERIFY_WITNESS_HELP_TEXT = """Usage: mvar-verify-witness <ledger.jsonl> [option
 
 Options:
   --require-chain     Require valid signature chain
-  --qseal-key PATH    Verify using provided QSEAL key
+  --qseal-key PATH    Verify legacy hmac-sha256 signatures using provided key
   --quiet             Minimal output
   --json              JSON verification output
   -h, --help          Show help"""
@@ -513,8 +512,8 @@ def _parse_verify_witness_args(argv: List[str]) -> Dict[str, Any]:
 
 def _apply_qseal_key_path(qseal_key_path: Optional[str]) -> Tuple[Optional[str], bool]:
     """
-    Apply optional --qseal-key for HMAC verification mode by temporarily setting
-    QSEAL_SECRET from file contents.
+    Apply optional --qseal-key for legacy hmac-sha256 verification mode by
+    temporarily setting QSEAL_SECRET from file contents.
     """
     if not qseal_key_path:
         return None, False

--- a/mvar-core/decision_ledger.py
+++ b/mvar-core/decision_ledger.py
@@ -27,47 +27,32 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import hmac
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 
-# Deterministic local HMAC fallback for stable cross-env behavior.
-verify_entry = None
-_external_sign_entry = None
+try:
+    from .qseal import QSealSigner
+except ImportError:
+    from qseal import QSealSigner
 
 QSEAL_AVAILABLE = True
-QSEAL_MODE = "hmac-sha256"
-
-if QSEAL_MODE == "hmac-sha256":
-    print(
-        "ℹ️  QSEAL external signer not detected — decision ledger uses HMAC-SHA256 fallback "
-        "(runtime policy traces may still show local Ed25519 signer)"
-    )
+_LOGGER = logging.getLogger("mvar.decision_ledger")
 
 
 def generate_signature(payload: dict) -> str:
-    """Deterministic HMAC-SHA256 signature for fallback mode."""
+    """
+    Legacy deterministic HMAC-SHA256 signature helper.
+
+    This exists for backward compatibility with historical tests and
+    artifacts that used QSEAL_SECRET-based HMAC signatures directly.
+    """
     secret = os.getenv("QSEAL_SECRET", "").encode("utf-8")
     payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hmac.new(secret, payload_json.encode("utf-8"), hashlib.sha256).hexdigest()
-
-
-def sign_entry(entry: dict, agent_id: str = "mvar_decision_ledger") -> dict:
-    """
-    Sign entry with external Ed25519 path when available, otherwise local HMAC.
-    """
-    if QSEAL_MODE == "ed25519" and _external_sign_entry is not None:
-        return _external_sign_entry(entry, agent_id=agent_id)
-
-    signed = entry.copy()
-    signed["qseal_signature"] = generate_signature(entry)
-    signed["qseal_verified"] = True
-    signed["qseal_meta_hash"] = generate_signature(
-        {"agent_id": agent_id, "meta_hash": signed.get("meta_hash", "")}
-    )
-    return signed
 
 
 class MVARDecisionLedger:
@@ -117,7 +102,7 @@ class MVARDecisionLedger:
 
         Args:
             ledger_path: Path to JSONL ledger file
-            enable_qseal_signing: Enable cryptographic signatures (requires QSEAL_SECRET)
+            enable_qseal_signing: Enable cryptographic signatures via QSealSigner
         """
         self.ledger_path = Path(ledger_path)
         self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
@@ -129,15 +114,32 @@ class MVARDecisionLedger:
         # QSEAL signing (separate from enable_ledger flag)
         # QSEAL_AVAILABLE is True for both optional external engine and local fallback signer.
         self.enable_qseal_signing = enable_qseal_signing and QSEAL_AVAILABLE
-        self.qseal_mode = QSEAL_MODE if self.enable_qseal_signing else "none"
+        self.qseal_mode = "none"
         self.max_future_skew_seconds = int(os.getenv("MVAR_MAX_FUTURE_SKEW_SECONDS", "300"))
         self.debug_ledger = os.getenv("MVAR_DEBUG_LEDGER") == "1"
         self.max_ledger_bytes = int(os.getenv("MVAR_LEDGER_MAX_BYTES", str(10 * 1024 * 1024)))
         self.max_appends_per_minute = int(os.getenv("MVAR_LEDGER_MAX_APPENDS_PER_MINUTE", "600"))
         self._append_times: List[datetime] = []
-
-        if self.enable_qseal_signing and self.qseal_mode == "hmac-sha256" and not os.getenv("QSEAL_SECRET"):
-            raise ValueError("QSEAL_SECRET is required for HMAC signing mode")
+        self._qseal_signer: Optional[QSealSigner] = QSealSigner() if self.enable_qseal_signing else None
+        self.qseal_mode = (
+            str(self._qseal_signer.algorithm).lower()
+            if self._qseal_signer is not None
+            else "none"
+        )
+        self._runtime_profile = str(os.getenv("MVAR_RUNTIME_PROFILE", "")).strip().lower()
+        self._require_ed25519 = (
+            os.getenv("MVAR_LEDGER_REQUIRE_ED25519", "0") == "1"
+            or self._runtime_profile == "prod_locked"
+        )
+        if self.enable_qseal_signing and self._require_ed25519 and self.qseal_mode != "ed25519":
+            raise RuntimeError(
+                "Ed25519 signing is required for this runtime profile; "
+                "ledger initialization failed closed."
+            )
+        if self.enable_qseal_signing and self.qseal_mode == "hmac-sha256":
+            _LOGGER.warning(
+                "Decision ledger using HMAC fallback; signatures are labeled hmac-sha256."
+            )
 
         # Cache for loaded scrolls (avoid repeated file I/O)
         self._scroll_cache: Optional[List[Dict]] = None
@@ -199,6 +201,56 @@ class MVARDecisionLedger:
         return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 
     @staticmethod
+    def _canonical_signature(algorithm: str, signature_hex: str) -> str:
+        return f"{algorithm}:{signature_hex}"
+
+    @staticmethod
+    def _split_signature(signature_value: str, claimed_algorithm: str) -> tuple[str, str]:
+        raw = str(signature_value or "").strip()
+        if ":" in raw:
+            algorithm, signature_hex = raw.split(":", 1)
+            return algorithm.strip().lower(), signature_hex.strip()
+        return claimed_algorithm, raw
+
+    @staticmethod
+    def _signed_payload(scroll: dict) -> bytes:
+        signed_portion = {
+            k: v
+            for k, v in scroll.items()
+            if k
+            not in ("qseal_signature", "qseal_verified", "qseal_meta_hash", "qseal_algorithm")
+        }
+        return json.dumps(signed_portion, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    def _sign_payload(self, payload: bytes) -> tuple[str, str, bool]:
+        if not self.enable_qseal_signing or self._qseal_signer is None:
+            return "none", "UNSIGNED", False
+
+        algorithm = str(self._qseal_signer.algorithm).lower()
+        if algorithm == "ed25519":
+            private_key = getattr(self._qseal_signer, "_private_key", None)
+            public_key = getattr(self._qseal_signer, "_public_key", None)
+            if private_key is None or public_key is None:
+                raise RuntimeError("Ed25519 signer unavailable")
+            signature_hex = private_key.sign(payload).hex()
+            verified = False
+            try:
+                public_key.verify(bytes.fromhex(signature_hex), payload)
+                verified = True
+            except Exception:
+                verified = False
+            return algorithm, signature_hex, verified
+
+        if algorithm == "hmac-sha256":
+            hmac_key = getattr(self._qseal_signer, "_hmac_key", None)
+            if hmac_key is None:
+                raise RuntimeError("HMAC fallback key unavailable")
+            signature_hex = hmac.new(hmac_key, payload, hashlib.sha256).hexdigest()
+            return algorithm, signature_hex, True
+
+        raise RuntimeError(f"Unsupported signing algorithm: {algorithm}")
+
+    @staticmethod
     def _generate_nonce() -> str:
         return os.urandom(16).hex()
 
@@ -227,11 +279,29 @@ class MVARDecisionLedger:
 
         # Compute meta_hash before signing
         scroll["meta_hash"] = self._compute_meta_hash(scroll)
+        payload = self._signed_payload(scroll)
+        algorithm, signature_hex, verified = self._sign_payload(payload)
+        scroll["qseal_algorithm"] = algorithm
+        scroll["qseal_signature"] = self._canonical_signature(algorithm, signature_hex)
+        scroll["qseal_verified"] = bool(verified)
 
-        # Sign using QSEAL engine
-        signed = sign_entry(scroll, agent_id="mvar_decision_ledger")
-        signed["qseal_algorithm"] = self.qseal_mode
-        return signed
+        meta_payload = {"agent_id": "mvar_decision_ledger", "meta_hash": scroll.get("meta_hash", "")}
+        meta_payload_json = json.dumps(meta_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        if algorithm == "ed25519":
+            private_key = getattr(self._qseal_signer, "_private_key", None)
+            if private_key is None:
+                raise RuntimeError("Ed25519 signer unavailable for meta hash seal")
+            meta_sig_hex = private_key.sign(meta_payload_json).hex()
+            scroll["qseal_meta_hash"] = self._canonical_signature("ed25519", meta_sig_hex)
+        elif algorithm == "hmac-sha256":
+            hmac_key = getattr(self._qseal_signer, "_hmac_key", None)
+            if hmac_key is None:
+                raise RuntimeError("HMAC fallback key unavailable for meta hash seal")
+            meta_sig_hex = hmac.new(hmac_key, meta_payload_json, hashlib.sha256).hexdigest()
+            scroll["qseal_meta_hash"] = self._canonical_signature("hmac-sha256", meta_sig_hex)
+        else:
+            scroll["qseal_meta_hash"] = "none:UNSIGNED"
+        return scroll
 
     def _verify_scroll(self, scroll: dict) -> bool:
         """
@@ -250,8 +320,8 @@ class MVARDecisionLedger:
             return False  # Unsigned scrolls not trusted
 
         try:
-            claimed_algorithm = (scroll.get("qseal_algorithm") or "").lower()
-            if claimed_algorithm != self.qseal_mode:
+            claimed_algorithm = str(scroll.get("qseal_algorithm", "")).strip().lower()
+            if claimed_algorithm not in {"ed25519", "hmac-sha256"}:
                 return False
 
             timestamp = scroll.get("timestamp")
@@ -270,20 +340,42 @@ class MVARDecisionLedger:
             if "qseal_signature" not in scroll:
                 return False
 
-            if claimed_algorithm == "ed25519":
-                if verify_entry is None:
-                    return False
-                return bool(verify_entry(scroll))
-
-            if claimed_algorithm != "hmac-sha256":
+            payload = self._signed_payload(scroll)
+            signature_label = str(scroll.get("qseal_signature", ""))
+            signature_algorithm, signature_hex = self._split_signature(
+                signature_label, claimed_algorithm
+            )
+            if signature_algorithm != claimed_algorithm or not signature_hex:
                 return False
 
-            provided_sig = scroll["qseal_signature"]
-            verify_payload = {k: v for k, v in scroll.items()
-                             if k not in ("qseal_signature", "qseal_verified",
-                                         "qseal_meta_hash", "qseal_algorithm")}
-            expected_sig = generate_signature(verify_payload)
-            return hmac.compare_digest(provided_sig, expected_sig)
+            if claimed_algorithm == "ed25519":
+                if self._qseal_signer is None:
+                    return False
+                public_key = getattr(self._qseal_signer, "_public_key", None)
+                if public_key is None:
+                    return False
+                try:
+                    public_key.verify(bytes.fromhex(signature_hex), payload)
+                    return True
+                except Exception:
+                    return False
+
+            # HMAC transition mode:
+            # 1) verify against current QSealSigner fallback key when available
+            # 2) fallback to legacy QSEAL_SECRET-based verification for historical rows
+            if self._qseal_signer is not None:
+                hmac_key = getattr(self._qseal_signer, "_hmac_key", None)
+                if hmac_key is not None:
+                    expected = hmac.new(hmac_key, payload, hashlib.sha256).hexdigest()
+                    if hmac.compare_digest(signature_hex, expected):
+                        return True
+
+            legacy_secret = os.getenv("QSEAL_SECRET", "").encode("utf-8")
+            if legacy_secret:
+                expected = hmac.new(legacy_secret, payload, hashlib.sha256).hexdigest()
+                if hmac.compare_digest(signature_hex, expected):
+                    return True
+            return False
         except Exception as e:
             if self.debug_ledger:
                 print(f"⚠️  Signature verification failed: {e}")

--- a/mvar/governor.py
+++ b/mvar/governor.py
@@ -37,7 +37,7 @@ class ExecutionDecision:
     # "mvar-security"
 
     witness_signature: str
-    # "ed25519:<hex>"
+    # "ed25519:<hex>" | "hmac-sha256:<hex>"
 
     provenance: dict
     # full provenance dict
@@ -55,7 +55,7 @@ class ExecutionGovernor:
     """Maps ClawZero requests onto mvar-security control-plane decisions."""
 
     _PROFILE_MAP = {
-        "prod_locked": SecurityProfile.BALANCED,
+        "prod_locked": SecurityProfile.STRICT,
         "dev_strict": SecurityProfile.STRICT,
         "dev_balanced": SecurityProfile.BALANCED,
     }
@@ -73,6 +73,11 @@ class ExecutionGovernor:
         resolved_profile = policy_profile or profile
         self.profile_name = resolved_profile
         self.security_profile = self._PROFILE_MAP.get(resolved_profile, SecurityProfile.BALANCED)
+        os.environ["MVAR_RUNTIME_PROFILE"] = resolved_profile
+        if resolved_profile == "prod_locked":
+            os.environ["MVAR_ENFORCE_ED25519"] = "1"
+        else:
+            os.environ.setdefault("MVAR_ENFORCE_ED25519", "0")
         # ClawZero integration should not require pre-bundled policy artifacts to boot.
         os.environ["MVAR_REQUIRE_SIGNED_POLICY_BUNDLE"] = "0"
         os.environ["MVAR_POLICY_BUNDLE_PATH"] = ""
@@ -379,11 +384,7 @@ class ExecutionGovernor:
                 "verification_trace": evaluation_trace,
             }
         )
-        if seal.algorithm == "ed25519":
-            signature = f"ed25519:{seal.signature_hex}"
-        else:
-            digest = hashlib.sha256(str(payload).encode("utf-8")).hexdigest()
-            signature = f"ed25519:{digest}"
+        signature = f"{seal.algorithm}:{seal.signature_hex}"
 
         return ExecutionDecision(
             decision=decision,

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -1,6 +1,7 @@
 """API contract tests to prevent docs/example drift in future phases."""
 
 import inspect
+import os
 
 import pytest
 from mvar_adapters.base import MVARExecutionAdapter
@@ -153,34 +154,44 @@ def test_governor_bridge_decision_shape_contract(monkeypatch):
 
 
 def test_governor_witness_signature_uses_truthful_algorithm_label(monkeypatch):
+    original_env = os.environ.copy()
     monkeypatch.setenv("MVAR_REQUIRE_EXECUTION_TOKEN", "0")
     monkeypatch.setenv("MVAR_FAIL_CLOSED", "1")
     monkeypatch.setenv("MVAR_ENABLE_LEDGER", "0")
     monkeypatch.setenv("MVAR_ENABLE_TRUST_ORACLE", "0")
     monkeypatch.delenv("MVAR_ENFORCE_ED25519", raising=False)
 
-    from mvar.governor import ExecutionGovernor
+    try:
+        from mvar.governor import ExecutionGovernor
 
-    governor = ExecutionGovernor(policy_profile="dev_balanced")
-    decision = governor.evaluate(
-        {
-            "sink_type": "tool.custom",
-            "target": "status",
-            "arguments": {"command": "echo ok"},
-            "prompt_provenance": {"source": "user_request", "taint_level": "trusted"},
-        }
-    )
+        governor = ExecutionGovernor(policy_profile="dev_balanced")
+        decision = governor.evaluate(
+            {
+                "sink_type": "tool.custom",
+                "target": "status",
+                "arguments": {"command": "echo ok"},
+                "prompt_provenance": {"source": "user_request", "taint_level": "trusted"},
+            }
+        )
 
-    algorithm, signature_hex = str(decision.witness_signature).split(":", 1)
-    assert algorithm in {"ed25519", "hmac-sha256"}
-    assert signature_hex
+        algorithm, signature_hex = str(decision.witness_signature).split(":", 1)
+        assert algorithm in {"ed25519", "hmac-sha256"}
+        assert signature_hex
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)
 
 
 def test_governor_prod_locked_fails_closed_without_ed25519(monkeypatch):
+    original_env = os.environ.copy()
     monkeypatch.setattr(qseal, "_CRYPTO_AVAILABLE", False)
     monkeypatch.delenv("MVAR_ENFORCE_ED25519", raising=False)
 
-    from mvar.governor import ExecutionGovernor
+    try:
+        from mvar.governor import ExecutionGovernor
 
-    with pytest.raises(RuntimeError, match="MVAR_ENFORCE_ED25519=1"):
-        ExecutionGovernor(policy_profile="prod_locked")
+        with pytest.raises(RuntimeError, match="MVAR_ENFORCE_ED25519=1"):
+            ExecutionGovernor(policy_profile="prod_locked")
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -2,9 +2,11 @@
 
 import inspect
 
+import pytest
 from mvar_adapters.base import MVARExecutionAdapter
 from mvar_core.capability import CapabilityRuntime, build_shell_tool
 from mvar_core.provenance import ProvenanceGraph, provenance_user_input
+import mvar_core.qseal as qseal
 from mvar_core.sink_policy import (
     PolicyOutcome,
     SinkClassification,
@@ -148,3 +150,37 @@ def test_governor_bridge_decision_shape_contract(monkeypatch):
     assert prov.get("node_id")
     assert prov.get("integrity")
     assert prov.get("confidentiality")
+
+
+def test_governor_witness_signature_uses_truthful_algorithm_label(monkeypatch):
+    monkeypatch.setenv("MVAR_REQUIRE_EXECUTION_TOKEN", "0")
+    monkeypatch.setenv("MVAR_FAIL_CLOSED", "1")
+    monkeypatch.setenv("MVAR_ENABLE_LEDGER", "0")
+    monkeypatch.setenv("MVAR_ENABLE_TRUST_ORACLE", "0")
+    monkeypatch.delenv("MVAR_ENFORCE_ED25519", raising=False)
+
+    from mvar.governor import ExecutionGovernor
+
+    governor = ExecutionGovernor(policy_profile="dev_balanced")
+    decision = governor.evaluate(
+        {
+            "sink_type": "tool.custom",
+            "target": "status",
+            "arguments": {"command": "echo ok"},
+            "prompt_provenance": {"source": "user_request", "taint_level": "trusted"},
+        }
+    )
+
+    algorithm, signature_hex = str(decision.witness_signature).split(":", 1)
+    assert algorithm in {"ed25519", "hmac-sha256"}
+    assert signature_hex
+
+
+def test_governor_prod_locked_fails_closed_without_ed25519(monkeypatch):
+    monkeypatch.setattr(qseal, "_CRYPTO_AVAILABLE", False)
+    monkeypatch.delenv("MVAR_ENFORCE_ED25519", raising=False)
+
+    from mvar.governor import ExecutionGovernor
+
+    with pytest.raises(RuntimeError, match="MVAR_ENFORCE_ED25519=1"):
+        ExecutionGovernor(policy_profile="prod_locked")

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -6,9 +6,11 @@ import json
 import os
 from pathlib import Path
 
+import pytest
 import test_common  # noqa: F401
+import qseal
 from capability import CapabilityRuntime, CapabilityGrant, CapabilityType, build_shell_tool
-from decision_ledger import MVARDecisionLedger
+from decision_ledger import MVARDecisionLedger, generate_signature
 from provenance import ProvenanceGraph, provenance_user_input
 from sink_policy import SinkPolicy, register_common_sinks, PolicyOutcome
 
@@ -40,7 +42,8 @@ def test_ledger_fails_closed_on_algorithm_mismatch():
     assert decisions == []
 
 
-def test_sink_policy_blocks_shell_metacharacters():
+def test_sink_policy_blocks_shell_metacharacters(monkeypatch):
+    monkeypatch.setenv("MVAR_REQUIRE_SIGNED_POLICY_BUNDLE", "0")
     graph = ProvenanceGraph(enable_qseal=False)
     runtime = CapabilityRuntime()
     runtime.manifests["bash"] = build_shell_tool("bash", ["pytest", "ls"], ["/tmp/**"])
@@ -59,7 +62,8 @@ def test_sink_policy_blocks_shell_metacharacters():
     assert "Strict boundary denied target" in decision.reason
 
 
-def test_sink_policy_blocks_python_exec_by_default():
+def test_sink_policy_blocks_python_exec_by_default(monkeypatch):
+    monkeypatch.setenv("MVAR_REQUIRE_SIGNED_POLICY_BUNDLE", "0")
     graph = ProvenanceGraph(enable_qseal=False)
     runtime = CapabilityRuntime()
     runtime.manifests["bash"] = build_shell_tool("bash", ["python3", "ls"], ["/tmp/**"])
@@ -79,18 +83,108 @@ def test_sink_policy_blocks_python_exec_by_default():
     assert "allowlist" in decision.reason.lower()
 
 
-def test_ledger_requires_qseal_secret_in_hmac_mode():
+def test_ledger_initializes_without_qseal_secret():
     old_secret = os.environ.pop("QSEAL_SECRET", None)
     try:
-        raised = False
-        try:
-            MVARDecisionLedger(ledger_path="/tmp/mvar_hardening_no_secret.jsonl", enable_qseal_signing=True)
-        except ValueError:
-            raised = True
-        assert raised
+        ledger = MVARDecisionLedger(
+            ledger_path="/tmp/mvar_hardening_no_secret.jsonl",
+            enable_qseal_signing=True,
+        )
+        assert ledger.qseal_mode in {"ed25519", "hmac-sha256"}
     finally:
         if old_secret is not None:
             os.environ["QSEAL_SECRET"] = old_secret
+
+
+def test_ledger_prod_locked_fails_closed_without_ed25519(monkeypatch, tmp_path):
+    monkeypatch.setattr(qseal, "_CRYPTO_AVAILABLE", False)
+    monkeypatch.setenv("MVAR_RUNTIME_PROFILE", "prod_locked")
+    monkeypatch.delenv("MVAR_LEDGER_REQUIRE_ED25519", raising=False)
+
+    with pytest.raises(RuntimeError, match="Ed25519 signing is required"):
+        MVARDecisionLedger(
+            ledger_path=str(tmp_path / "prod_locked_no_ed25519.jsonl"),
+            enable_qseal_signing=True,
+        )
+
+
+def test_ledger_prod_locked_writes_ed25519_labels(monkeypatch, tmp_path):
+    if not qseal._CRYPTO_AVAILABLE:  # pragma: no cover - environment dependent
+        pytest.skip("Ed25519 unavailable in this environment")
+
+    monkeypatch.setenv("MVAR_RUNTIME_PROFILE", "prod_locked")
+    monkeypatch.delenv("MVAR_LEDGER_REQUIRE_ED25519", raising=False)
+
+    ledger = MVARDecisionLedger(
+        ledger_path=str(tmp_path / "prod_locked_ed25519.jsonl"),
+        enable_qseal_signing=True,
+    )
+    scroll_id = ledger.record_decision(
+        outcome="BLOCK",
+        sink=type("Sink", (), {"tool": "bash", "action": "exec"})(),
+        target="curl bad.example",
+        provenance_node_id="node_ed25519",
+        evaluation_trace=["contract:test"],
+        reason="contract",
+        policy_hash="contract_hash",
+    )
+    decision = ledger.get_decision(scroll_id)
+    assert decision is not None
+    assert decision["qseal_algorithm"] == "ed25519"
+    assert str(decision["qseal_signature"]).startswith("ed25519:")
+
+
+def test_ledger_dev_fallback_uses_truthful_hmac_label(monkeypatch, tmp_path):
+    monkeypatch.setattr(qseal, "_CRYPTO_AVAILABLE", False)
+    monkeypatch.setenv("MVAR_RUNTIME_PROFILE", "dev_balanced")
+    monkeypatch.delenv("MVAR_LEDGER_REQUIRE_ED25519", raising=False)
+
+    ledger = MVARDecisionLedger(
+        ledger_path=str(tmp_path / "dev_hmac_fallback.jsonl"),
+        enable_qseal_signing=True,
+    )
+    scroll_id = ledger.record_decision(
+        outcome="BLOCK",
+        sink=type("Sink", (), {"tool": "bash", "action": "exec"})(),
+        target="curl bad.example",
+        provenance_node_id="node_hmac",
+        evaluation_trace=["contract:test"],
+        reason="contract",
+        policy_hash="contract_hash",
+    )
+    decision = ledger.get_decision(scroll_id)
+    assert decision is not None
+    assert decision["qseal_algorithm"] == "hmac-sha256"
+    assert str(decision["qseal_signature"]).startswith("hmac-sha256:")
+
+
+def test_ledger_reads_legacy_hmac_signature_with_qseal_secret(monkeypatch, tmp_path):
+    monkeypatch.setenv("QSEAL_SECRET", "legacy_contract_secret")
+    ledger = MVARDecisionLedger(
+        ledger_path=str(tmp_path / "legacy_hmac_read.jsonl"),
+        enable_qseal_signing=True,
+    )
+    scroll_id = ledger.record_decision(
+        outcome="BLOCK",
+        sink=type("Sink", (), {"tool": "bash", "action": "exec"})(),
+        target="curl bad.example",
+        provenance_node_id="node_legacy",
+        evaluation_trace=["contract:test"],
+        reason="contract",
+        policy_hash="contract_hash",
+    )
+    decision = ledger.get_decision(scroll_id)
+    assert decision is not None
+
+    legacy_scroll = dict(decision)
+    legacy_scroll["qseal_algorithm"] = "hmac-sha256"
+    payload = {
+        k: v
+        for k, v in legacy_scroll.items()
+        if k not in ("qseal_signature", "qseal_verified", "qseal_meta_hash", "qseal_algorithm")
+    }
+    legacy_scroll["qseal_signature"] = generate_signature(payload)
+    assert ledger._verify_scroll(legacy_scroll) is True  # noqa: SLF001
 
 
 def _snapshot_http_env():

--- a/tests/test_witness_verifier.py
+++ b/tests/test_witness_verifier.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
+import os
 import sys
 from types import SimpleNamespace
 
 import pytest
 
 from mvar_core.cli_ledger import main_verify_witness, verify_witness_file
-from mvar_core.decision_ledger import MVARDecisionLedger, generate_signature
+from mvar_core.decision_ledger import MVARDecisionLedger
 
 
 def _build_signed_witness_jsonl(tmp_path, monkeypatch, *, count: int = 2):
@@ -34,13 +37,24 @@ def _read_jsonl(path):
 
 def _resign_scroll(tmp_path, scroll):
     ledger = MVARDecisionLedger(ledger_path=str(tmp_path / "noop.jsonl"), enable_qseal_signing=True)
+    algorithm = str(scroll.get("qseal_algorithm", ledger.qseal_mode)).strip().lower()
+    assert algorithm in {"ed25519", "hmac-sha256"}
+
+    scroll["qseal_algorithm"] = algorithm
     scroll["meta_hash"] = ledger._compute_meta_hash(scroll)  # noqa: SLF001
-    payload = {
-        k: v
-        for k, v in scroll.items()
-        if k not in ("qseal_signature", "qseal_verified", "qseal_meta_hash", "qseal_algorithm")
-    }
-    scroll["qseal_signature"] = generate_signature(payload)
+    payload = ledger._signed_payload(scroll)  # noqa: SLF001
+
+    if algorithm == "ed25519":
+        private_key = getattr(ledger._qseal_signer, "_private_key", None)  # noqa: SLF001
+        assert private_key is not None
+        signature_hex = private_key.sign(payload).hex()
+    else:
+        hmac_key = getattr(ledger._qseal_signer, "_hmac_key", None)  # noqa: SLF001
+        if hmac_key is None:
+            hmac_key = os.getenv("QSEAL_SECRET", "").encode("utf-8")
+        signature_hex = hmac.new(hmac_key, payload, hashlib.sha256).hexdigest()
+
+    scroll["qseal_signature"] = f"{algorithm}:{signature_hex}"
     return scroll
 
 
@@ -247,7 +261,7 @@ def test_cli_help_outputs_exact_text(monkeypatch, capsys):
         "Usage: mvar-verify-witness <ledger.jsonl> [options]\n\n"
         "Options:\n"
         "  --require-chain     Require valid signature chain\n"
-        "  --qseal-key PATH    Verify using provided QSEAL key\n"
+        "  --qseal-key PATH    Verify legacy hmac-sha256 signatures using provided key\n"
         "  --quiet             Minimal output\n"
         "  --json              JSON verification output\n"
         "  -h, --help          Show help"


### PR DESCRIPTION
Implements Item 1:
- Removes misleading ed25519 labels on HMAC outputs
- Makes Ed25519 default via QSealSigner with truthful fallback labels
- Enforces fail-closed in prod_locked when Ed25519 unavailable
- Preserves backward read compatibility for legacy HMAC rows
- Updates verifier/CLI/test contracts accordingly