### PR TITLE
feat: enforce vaulted execution mediation by default

### DIFF
--- a/mvar-core/credential_vault.py
+++ b/mvar-core/credential_vault.py
@@ -12,19 +12,29 @@ Architecture:
     Never exposes credentials to network. Tokens are time-bound and signed.
 """
 
+import base64
 import json
 import hashlib
+import hmac
+import os
 import time
 import socket
 import threading
-from dataclasses import dataclass, asdict
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, Tuple
 from enum import Enum
 
 # Import QSEAL from local mvar-core package
 from .qseal import QSealSigner
+
+try:
+    from cryptography.fernet import Fernet, InvalidToken
+except ImportError as exc:  # pragma: no cover - enforced at runtime
+    raise RuntimeError(
+        "CredentialVault requires 'cryptography' for encrypted credential storage"
+    ) from exc
 
 
 class CredentialType(Enum):
@@ -56,16 +66,16 @@ class CredentialToken:
     - Single-use capable (optional)
     """
     token_id: str
+    credential_id: str
+    credential_version: int
     credential_type: CredentialType
     scope: CredentialScope
     issued_at: float  # Unix timestamp
     expires_at: float  # Unix timestamp
     revoked: bool
     single_use: bool
+    verification_context: Dict[str, Any]
     qseal_signature: Dict[str, str]
-
-    # Encrypted credential payload (base64-encoded)
-    encrypted_payload: str
 
     def is_valid(self) -> bool:
         """Check if token is still valid (not expired, not revoked)"""
@@ -79,21 +89,43 @@ class CredentialToken:
         """Seconds until expiration"""
         return max(0, self.expires_at - time.time())
 
-    def to_dict(self) -> Dict[str, Any]:
-        """Serialize to dictionary"""
+    def to_reference_dict(self) -> Dict[str, Any]:
+        """Serialize safe token reference (never includes raw credential material)."""
         return {
             "token_id": self.token_id,
+            "credential_id": self.credential_id,
+            "credential_version": self.credential_version,
             "credential_type": self.credential_type.value,
             "scope": self.scope.value,
             "issued_at": self.issued_at,
             "expires_at": self.expires_at,
             "revoked": self.revoked,
             "single_use": self.single_use,
+            "verification_context": self.verification_context,
             "qseal_signature": self.qseal_signature,
-            "encrypted_payload": self.encrypted_payload,
             "is_valid": self.is_valid(),
             "time_remaining": self.time_remaining()
         }
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Backward-compatible alias for reference serialization."""
+        return self.to_reference_dict()
+
+
+@dataclass
+class CredentialRecord:
+    """Durable encrypted credential record metadata."""
+    credential_id: str
+    encrypted_payload: str
+    credential_type: str
+    created_at: float
+    updated_at: float
+    expires_at: Optional[float]
+    revoked: bool
+    version: int
+
+    def is_expired(self) -> bool:
+        return self.expires_at is not None and time.time() >= self.expires_at
 
 
 class CredentialVault:
@@ -115,31 +147,154 @@ class CredentialVault:
         self,
         socket_path: str = "/tmp/mvar_credential_vault.sock",
         default_ttl_seconds: int = 300,  # 5 minutes
-        enable_audit_log: bool = True
+        enable_audit_log: bool = True,
+        vault_dir: Optional[str] = None,
+        require_caller_auth: bool = True,
+        allowed_uids: Optional[list[int]] = None,
     ):
         self.socket_path = socket_path
         self.default_ttl_seconds = default_ttl_seconds
         self.enable_audit_log = enable_audit_log
+        self.profile_name = str(os.getenv("MVAR_RUNTIME_PROFILE", "dev_balanced")).strip().lower()
+        if self.profile_name not in {"prod_locked", "dev_strict", "dev_balanced"}:
+            self.profile_name = "dev_balanced"
 
         # Initialize QSEAL signer
         self.qseal = QSealSigner()
+        self._require_ed25519 = self.profile_name == "prod_locked"
+        if self._require_ed25519 and self.qseal.algorithm != "ed25519":
+            raise RuntimeError("CredentialVault requires Ed25519 signing in prod_locked mode")
+
+        # Runtime/auth configuration
+        self.require_caller_auth = require_caller_auth
+        default_uid = os.getuid() if hasattr(os, "getuid") else 0
+        if allowed_uids is None:
+            self.allowed_uids = {default_uid}
+        else:
+            self.allowed_uids = {int(uid) for uid in allowed_uids}
+
+        # Durable encrypted credential storage
+        root_dir = Path(vault_dir or os.getenv("MVAR_VAULT_DIR", str(Path.home() / ".mvar" / "vault")))
+        root_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(root_dir, 0o700)
+        except OSError:
+            pass
+        self._vault_dir = root_dir
+        self._credentials_path = self._vault_dir / "credentials.enc"
+        self._credentials_key_path = self._vault_dir / "credentials.key"
+        self._audit_log_path = self._vault_dir / "audit.jsonl"
+        self._fernet = self._initialize_fernet()
 
         # Token registry: {token_id: CredentialToken}
         self.tokens: Dict[str, CredentialToken] = {}
 
-        # Credential store: {credential_id: encrypted_credential}
-        # In production: use proper key management (HSM, Vault, etc.)
-        self.credentials: Dict[str, str] = {}
+        # Durable credential metadata (encrypted payloads are stored encrypted-at-rest)
+        self.credentials: Dict[str, CredentialRecord] = self._load_credentials()
 
-        # Audit log
+        # In-memory cache for latest audit events.
         self.audit_log: list = []
+        self._audit_prev_signature = self._load_last_audit_signature()
 
-        # Revocation triggers (anomaly score thresholds)
-        self.psi_anomaly_threshold = 5.0  # 5-sigma deviation
+        # Revocation triggers (anomaly score thresholds, profile-aware).
+        self.psi_anomaly_threshold = float(
+            os.getenv(
+                "MVAR_VAULT_PSI_THRESHOLD",
+                {
+                    "prod_locked": "3.0",
+                    "dev_strict": "4.0",
+                    "dev_balanced": "5.0",
+                }[self.profile_name],
+            )
+        )
 
         # Server socket
         self.server_socket: Optional[socket.socket] = None
         self.running = False
+
+    def _initialize_fernet(self) -> Fernet:
+        """Initialize durable encryption key for credential storage."""
+        if self._credentials_key_path.exists():
+            key = self._credentials_key_path.read_bytes()
+        else:
+            key = Fernet.generate_key()
+            self._credentials_key_path.write_bytes(key)
+            try:
+                os.chmod(self._credentials_key_path, 0o600)
+            except OSError:
+                pass
+        return Fernet(key)
+
+    def _persist_credentials(self) -> None:
+        records = {
+            credential_id: {
+                "credential_id": rec.credential_id,
+                "encrypted_payload": rec.encrypted_payload,
+                "credential_type": rec.credential_type,
+                "created_at": rec.created_at,
+                "updated_at": rec.updated_at,
+                "expires_at": rec.expires_at,
+                "revoked": rec.revoked,
+                "version": rec.version,
+            }
+            for credential_id, rec in self.credentials.items()
+        }
+        plaintext = json.dumps(records, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        encrypted = self._fernet.encrypt(plaintext)
+        temp_path = self._credentials_path.with_suffix(".tmp")
+        temp_path.write_bytes(encrypted)
+        try:
+            os.chmod(temp_path, 0o600)
+        except OSError:
+            pass
+        temp_path.replace(self._credentials_path)
+        try:
+            os.chmod(self._credentials_path, 0o600)
+        except OSError:
+            pass
+
+    def _load_credentials(self) -> Dict[str, CredentialRecord]:
+        if not self._credentials_path.exists():
+            return {}
+        try:
+            encrypted = self._credentials_path.read_bytes()
+            plaintext = self._fernet.decrypt(encrypted)
+            payload = json.loads(plaintext.decode("utf-8"))
+        except (InvalidToken, ValueError, OSError, json.JSONDecodeError):
+            return {}
+        records: Dict[str, CredentialRecord] = {}
+        for credential_id, raw in payload.items():
+            records[str(credential_id)] = CredentialRecord(
+                credential_id=str(raw.get("credential_id", credential_id)),
+                encrypted_payload=str(raw.get("encrypted_payload", "")),
+                credential_type=str(raw.get("credential_type", CredentialType.API_KEY.value)),
+                created_at=float(raw.get("created_at", time.time())),
+                updated_at=float(raw.get("updated_at", time.time())),
+                expires_at=(
+                    float(raw["expires_at"])
+                    if raw.get("expires_at") is not None
+                    else None
+                ),
+                revoked=bool(raw.get("revoked", False)),
+                version=int(raw.get("version", 1)),
+            )
+        return records
+
+    def _load_last_audit_signature(self) -> Optional[str]:
+        if not self._audit_log_path.exists():
+            return None
+        try:
+            with self._audit_log_path.open("r", encoding="utf-8") as handle:
+                last_line = ""
+                for line in handle:
+                    if line.strip():
+                        last_line = line
+                if not last_line:
+                    return None
+                parsed = json.loads(last_line)
+                return str(parsed.get("qseal_signature")) or None
+        except Exception:
+            return None
 
     def start(self):
         """Start the vault server (Unix domain socket)"""
@@ -151,6 +306,10 @@ class CredentialVault:
         # Create Unix domain socket
         self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.server_socket.bind(self.socket_path)
+        try:
+            os.chmod(self.socket_path, 0o600)
+        except OSError:
+            pass
         self.server_socket.listen(5)
 
         self.running = True
@@ -175,6 +334,31 @@ class CredentialVault:
 
         print("[CredentialVault] Stopped")
 
+    def _caller_identity(self, client_socket: socket.socket) -> Tuple[Optional[int], Optional[int]]:
+        """Resolve Unix peer credentials (uid, gid) for caller authentication."""
+        try:
+            if hasattr(client_socket, "getpeereid"):
+                uid, gid = client_socket.getpeereid()
+                return int(uid), int(gid)
+        except Exception:
+            pass
+        try:
+            import struct
+
+            creds = client_socket.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+            _pid, uid, gid = struct.unpack("3i", creds)
+            return int(uid), int(gid)
+        except Exception:
+            return None, None
+
+    def _authenticate_caller(self, client_socket: socket.socket) -> bool:
+        if not self.require_caller_auth:
+            return True
+        uid, _gid = self._caller_identity(client_socket)
+        if uid is None:
+            return False
+        return uid in self.allowed_uids
+
     def _server_loop(self):
         """Main server loop - accept connections and handle requests"""
         while self.running:
@@ -194,6 +378,11 @@ class CredentialVault:
     def _handle_request(self, client_socket: socket.socket):
         """Handle a single client request"""
         try:
+            if not self._authenticate_caller(client_socket):
+                response = {"success": False, "error": "caller_authentication_failed"}
+                client_socket.send(json.dumps(response).encode())
+                return
+
             # Read request (JSON-encoded)
             request_data = client_socket.recv(4096).decode()
             request = json.loads(request_data)
@@ -205,8 +394,16 @@ class CredentialVault:
                 response = self._handle_issue_token(request)
             elif action == "verify_token":
                 response = self._handle_verify_token(request)
+            elif action == "validate_token_use":
+                response = self._handle_validate_token_use(request)
             elif action == "revoke_token":
                 response = self._handle_revoke_token(request)
+            elif action == "create_credential":
+                response = self._handle_create_credential(request)
+            elif action == "rotate_credential":
+                response = self._handle_rotate_credential(request)
+            elif action == "revoke_credential":
+                response = self._handle_revoke_credential(request)
             elif action == "check_psi_anomaly":
                 response = self._handle_psi_anomaly(request)
             else:
@@ -221,70 +418,146 @@ class CredentialVault:
         finally:
             client_socket.close()
 
-    def _handle_issue_token(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        """Issue a new credential token"""
-        credential_id = request.get("credential_id")
-        credential_type = CredentialType(request.get("credential_type", "api_key"))
-        scope = CredentialScope(request.get("scope", "read"))
-        ttl_seconds = request.get("ttl_seconds", self.default_ttl_seconds)
-        single_use = request.get("single_use", False)
-        verification_context = request.get("verification_context", {})
+    def _sign_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Cryptographically sign an arbitrary payload with truthful algorithm labeling."""
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        algorithm = str(self.qseal.algorithm).lower()
+        payload_hash = hashlib.sha256(canonical).hexdigest()
 
-        # Verify credential exists
-        if credential_id not in self.credentials:
+        if algorithm == "ed25519":
+            private_key = getattr(self.qseal, "_private_key", None)
+            public_key = getattr(self.qseal, "_public_key", None)
+            if private_key is None or public_key is None:
+                raise RuntimeError("Ed25519 signer unavailable")
+            signature_hex = private_key.sign(canonical).hex()
+            verified = False
+            try:
+                public_key.verify(bytes.fromhex(signature_hex), canonical)
+                verified = True
+            except Exception:
+                verified = False
+            return {
+                "algorithm": "ed25519",
+                "signature": f"ed25519:{signature_hex}",
+                "verified": verified,
+                "payload_hash": payload_hash,
+                "public_key_hex": self.qseal.public_key_hex,
+            }
+
+        if algorithm == "hmac-sha256":
+            hmac_key = getattr(self.qseal, "_hmac_key", None)
+            if hmac_key is None:
+                raise RuntimeError("HMAC fallback key unavailable")
+            signature_hex = hmac.new(hmac_key, canonical, hashlib.sha256).hexdigest()
+            return {
+                "algorithm": "hmac-sha256",
+                "signature": f"hmac-sha256:{signature_hex}",
+                "verified": True,
+                "payload_hash": payload_hash,
+                "public_key_hex": self.qseal.public_key_hex,
+            }
+
+        raise RuntimeError(f"Unsupported signing algorithm: {algorithm}")
+
+    def _credential_record(self, credential_id: str) -> Optional[CredentialRecord]:
+        record = self.credentials.get(str(credential_id))
+        if record is None:
+            return None
+        if record.is_expired():
+            record.revoked = True
+            self._persist_credentials()
+        if record.revoked:
+            return None
+        return record
+
+    def _handle_create_credential(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        credential_id = str(request.get("credential_id", "")).strip()
+        encrypted_credential = str(request.get("encrypted_credential", "")).strip()
+        if not credential_id or not encrypted_credential:
+            return {"success": False, "error": "credential_id and encrypted_credential are required"}
+        created = self.add_credential(
+            credential_id=credential_id,
+            encrypted_credential=encrypted_credential,
+            credential_type=str(request.get("credential_type", CredentialType.API_KEY.value)),
+            ttl_seconds=request.get("ttl_seconds"),
+        )
+        return {"success": True, "credential": created}
+
+    def _handle_rotate_credential(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        credential_id = str(request.get("credential_id", "")).strip()
+        encrypted_credential = str(request.get("encrypted_credential", "")).strip()
+        if not credential_id or not encrypted_credential:
+            return {"success": False, "error": "credential_id and encrypted_credential are required"}
+        rotated = self.rotate_credential(credential_id, encrypted_credential)
+        if rotated is None:
             return {"success": False, "error": f"Credential {credential_id} not found"}
+        return {"success": True, "credential": rotated}
 
-        # Generate token ID
+    def _handle_revoke_credential(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        credential_id = str(request.get("credential_id", "")).strip()
+        reason = str(request.get("reason", "manual_credential_revocation"))
+        if not credential_id:
+            return {"success": False, "error": "credential_id is required"}
+        return {"success": self.revoke_credential(credential_id, reason=reason)}
+
+    def _handle_issue_token(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Issue a new credential token reference (never raw credential material)."""
+        credential_id = str(request.get("credential_id", "")).strip()
+        credential_type = CredentialType(str(request.get("credential_type", "api_key")))
+        scope = CredentialScope(str(request.get("scope", "read")))
+        ttl_seconds = int(request.get("ttl_seconds", self.default_ttl_seconds))
+        single_use = bool(request.get("single_use", False))
+        verification_context = dict(request.get("verification_context", {}))
+
+        if not credential_id:
+            return {"success": False, "error": "credential_id is required"}
+
+        record = self._credential_record(credential_id)
+        if record is None:
+            return {"success": False, "error": f"Credential {credential_id} unavailable"}
+
         token_id = self._generate_token_id(credential_id)
-
-        # Get encrypted credential payload
-        encrypted_payload = self.credentials[credential_id]
-
-        # Create token metadata for QSEAL
         now = time.time()
-        token_metadata = {
+        token_payload = {
             "token_id": token_id,
             "credential_id": credential_id,
+            "credential_version": record.version,
             "credential_type": credential_type.value,
             "scope": scope.value,
             "issued_at": now,
             "expires_at": now + ttl_seconds,
             "single_use": single_use,
-            "verification_context": verification_context
+            "verification_context": verification_context,
         }
+        signature = self._sign_payload(token_payload)
 
-        # QSEAL signature
-        sealed_metadata = self.qseal.seal_result(token_metadata)
-
-        # Create token
         token = CredentialToken(
             token_id=token_id,
+            credential_id=credential_id,
+            credential_version=record.version,
             credential_type=credential_type,
             scope=scope,
             issued_at=now,
             expires_at=now + ttl_seconds,
             revoked=False,
             single_use=single_use,
-            qseal_signature=sealed_metadata.to_dict(),
-            encrypted_payload=encrypted_payload
+            verification_context=verification_context,
+            qseal_signature=signature,
         )
-
-        # Store token
         self.tokens[token_id] = token
 
-        # Audit log
-        self._audit_log("token_issued", {
-            "token_id": token_id,
-            "credential_id": credential_id,
-            "scope": scope.value,
-            "ttl_seconds": ttl_seconds,
-            "verification_context": verification_context
-        })
-
-        return {
-            "success": True,
-            "token": token.to_dict()
-        }
+        self._audit_log(
+            "token_issued",
+            {
+                "token_id": token_id,
+                "credential_id": credential_id,
+                "credential_version": record.version,
+                "scope": scope.value,
+                "ttl_seconds": ttl_seconds,
+                "verification_context": verification_context,
+            },
+        )
+        return {"success": True, "token": token.to_reference_dict()}
 
     def _handle_verify_token(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Verify a token's validity"""
@@ -295,11 +568,12 @@ class CredentialVault:
 
         token = self.tokens[token_id]
 
-        # Check if single-use token has already been consumed
-        if token.single_use and not token.is_valid():
-            return {"success": False, "error": "Single-use token already consumed"}
+        record = self._credential_record(token.credential_id)
+        if record is None:
+            return {"success": False, "valid": False, "error": "credential_revoked_or_expired"}
+        if int(record.version) != int(token.credential_version):
+            return {"success": False, "valid": False, "error": "credential_rotated_token_stale"}
 
-        # Mark single-use token as consumed
         if token.single_use and token.is_valid():
             token.revoked = True
             self._audit_log("single_use_token_consumed", {"token_id": token_id})
@@ -309,6 +583,51 @@ class CredentialVault:
             "valid": token.is_valid(),
             "token": token.to_dict()
         }
+
+    def _handle_validate_token_use(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate token against sink/provenance policy at use-time."""
+        token_id = str(request.get("token_id", "")).strip()
+        sink_risk = str(request.get("sink_risk", "")).strip().lower()
+        request_integrity = str(request.get("request_integrity", "unknown")).strip().lower()
+        provenance_node_hash = str(request.get("provenance_node_hash", "")).strip()
+        policy_hash = str(request.get("policy_hash", "")).strip()
+        session_id = str(request.get("session_id", "")).strip()
+
+        verify = self._handle_verify_token({"token_id": token_id})
+        if not verify.get("success") or not verify.get("valid"):
+            return {"success": False, "valid": False, "error": verify.get("error", "token_invalid")}
+
+        token_data = verify.get("token", {})
+        context = dict(token_data.get("verification_context", {}))
+        issue_integrity = str(context.get("integrity_at_issue", "unknown")).strip().lower()
+        issue_sink = str(context.get("sink_risk", "")).strip().lower()
+
+        if sink_risk == "critical":
+            if issue_integrity == "untrusted" or request_integrity == "untrusted":
+                self._audit_log(
+                    "token_use_blocked_untrusted_critical",
+                    {"token_id": token_id, "issue_integrity": issue_integrity, "request_integrity": request_integrity},
+                )
+                return {"success": False, "valid": False, "error": "untrusted_to_critical_sink"}
+
+        if session_id and context.get("session_id") and str(context.get("session_id")) != session_id:
+            return {"success": False, "valid": False, "error": "session_binding_mismatch"}
+        if provenance_node_hash and context.get("provenance_node_hash") and str(context.get("provenance_node_hash")) != provenance_node_hash:
+            return {"success": False, "valid": False, "error": "provenance_binding_mismatch"}
+        if policy_hash and context.get("policy_hash") and str(context.get("policy_hash")) != policy_hash:
+            return {"success": False, "valid": False, "error": "policy_binding_mismatch"}
+        if issue_sink and sink_risk and issue_sink != sink_risk:
+            return {"success": False, "valid": False, "error": "sink_risk_mismatch"}
+
+        self._audit_log(
+            "token_use_validated",
+            {
+                "token_id": token_id,
+                "sink_risk": sink_risk,
+                "session_id": session_id,
+            },
+        )
+        return {"success": True, "valid": True}
 
     def _handle_revoke_token(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Revoke a token"""
@@ -329,23 +648,20 @@ class CredentialVault:
         session_id = request.get("session_id")
 
         # Calculate anomaly score
-        if psi_sigma > 0:
-            anomaly_score = abs(psi_current - psi_baseline) / psi_sigma
-        else:
+        try:
+            if psi_sigma and float(psi_sigma) > 0:
+                anomaly_score = abs(float(psi_current) - float(psi_baseline)) / float(psi_sigma)
+            else:
+                anomaly_score = 0.0
+        except (TypeError, ValueError):
             anomaly_score = 0.0
 
         # Check threshold
         if anomaly_score >= self.psi_anomaly_threshold:
-            # REVOKE ALL TOKENS for this session
-            revoked_count = 0
-            for token in self.tokens.values():
-                if token.is_valid():
-                    # In production: check token session_id from verification_context
-                    self._revoke_token(
-                        token.token_id,
-                        reason=f"psi_anomaly_detected (score={anomaly_score:.2f}σ)"
-                    )
-                    revoked_count += 1
+            revoked_count = self.revoke_all_credentials(
+                reason=f"psi_anomaly_detected (score={anomaly_score:.2f}σ)",
+                session_id=str(session_id or ""),
+            )
 
             self._audit_log("psi_anomaly_mass_revocation", {
                 "session_id": session_id,
@@ -384,6 +700,14 @@ class CredentialVault:
 
         return True
 
+    def _revoke_tokens_for_credential(self, credential_id: str, reason: str) -> int:
+        revoked_count = 0
+        for token in self.tokens.values():
+            if token.credential_id == credential_id and token.is_valid():
+                if self._revoke_token(token.token_id, reason=reason):
+                    revoked_count += 1
+        return revoked_count
+
     def _generate_token_id(self, credential_id: str) -> str:
         """Generate unique token ID"""
         timestamp = str(time.time())
@@ -395,18 +719,37 @@ class CredentialVault:
         if not self.enable_audit_log:
             return
 
-        log_entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+        payload = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "event_type": event_type,
-            "details": details
+            "details": details,
+            "prev_signature": self._audit_prev_signature or "",
+        }
+        signature = self._sign_payload(payload)
+        log_entry = {
+            **payload,
+            "qseal_algorithm": signature["algorithm"],
+            "qseal_signature": signature["signature"],
+            "qseal_verified": bool(signature["verified"]),
+            "payload_hash": signature["payload_hash"],
         }
 
         self.audit_log.append(log_entry)
+        self._audit_prev_signature = str(log_entry.get("qseal_signature") or self._audit_prev_signature or "")
+        with self._audit_log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(log_entry, sort_keys=True) + "\n")
+        try:
+            os.chmod(self._audit_log_path, 0o600)
+        except OSError:
+            pass
 
-        # Optional: write to disk for persistence
-        # In production: send to SIEM, append to QSEAL chain, etc.
-
-    def add_credential(self, credential_id: str, encrypted_credential: str):
+    def add_credential(
+        self,
+        credential_id: str,
+        encrypted_credential: str,
+        credential_type: str = CredentialType.API_KEY.value,
+        ttl_seconds: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """
         Add a credential to the vault.
 
@@ -417,12 +760,114 @@ class CredentialVault:
         In production: credentials should be encrypted with proper key management.
         For MVP: we accept pre-encrypted credentials.
         """
-        self.credentials[credential_id] = encrypted_credential
-        self._audit_log("credential_added", {"credential_id": credential_id})
+        now = time.time()
+        expires_at = (now + int(ttl_seconds)) if ttl_seconds is not None else None
+        record = CredentialRecord(
+            credential_id=credential_id,
+            encrypted_payload=encrypted_credential,
+            credential_type=credential_type,
+            created_at=now,
+            updated_at=now,
+            expires_at=expires_at,
+            revoked=False,
+            version=1,
+        )
+        self.credentials[credential_id] = record
+        self._persist_credentials()
+        self._audit_log(
+            "credential_added",
+            {
+                "credential_id": credential_id,
+                "credential_type": credential_type,
+                "expires_at": expires_at,
+                "version": 1,
+            },
+        )
+        return {
+            "credential_id": credential_id,
+            "credential_type": credential_type,
+            "expires_at": expires_at,
+            "version": 1,
+        }
+
+    def rotate_credential(self, credential_id: str, encrypted_credential: str) -> Optional[Dict[str, Any]]:
+        record = self.credentials.get(credential_id)
+        if record is None:
+            return None
+        record.encrypted_payload = encrypted_credential
+        record.updated_at = time.time()
+        record.version = int(record.version) + 1
+        record.revoked = False
+        self._persist_credentials()
+        revoked_tokens = self._revoke_tokens_for_credential(
+            credential_id,
+            reason=f"credential_rotated_v{record.version}",
+        )
+        self._audit_log(
+            "credential_rotated",
+            {
+                "credential_id": credential_id,
+                "new_version": record.version,
+                "revoked_tokens": revoked_tokens,
+            },
+        )
+        return {"credential_id": credential_id, "version": record.version}
+
+    def revoke_credential(self, credential_id: str, reason: str = "manual_credential_revocation") -> bool:
+        record = self.credentials.get(credential_id)
+        if record is None:
+            return False
+        if not record.revoked:
+            record.revoked = True
+            record.updated_at = time.time()
+            self._persist_credentials()
+        revoked_tokens = self._revoke_tokens_for_credential(credential_id, reason=reason)
+        self._audit_log(
+            "credential_revoked",
+            {
+                "credential_id": credential_id,
+                "reason": reason,
+                "revoked_tokens": revoked_tokens,
+            },
+        )
+        return True
+
+    def revoke_all_credentials(self, reason: str, session_id: str = "") -> int:
+        revoked_credentials = 0
+        revoked_tokens = 0
+        for record in self.credentials.values():
+            if not record.revoked:
+                record.revoked = True
+                record.updated_at = time.time()
+                revoked_credentials += 1
+            revoked_tokens += self._revoke_tokens_for_credential(record.credential_id, reason=reason)
+        self._persist_credentials()
+        self._audit_log(
+            "credential_mass_revocation",
+            {
+                "reason": reason,
+                "session_id": session_id,
+                "credentials_revoked": revoked_credentials,
+                "tokens_revoked": revoked_tokens,
+            },
+        )
+        return revoked_tokens
 
     def get_audit_log(self) -> list:
         """Retrieve audit log"""
-        return self.audit_log.copy()
+        if not self._audit_log_path.exists():
+            return self.audit_log.copy()
+        events = []
+        with self._audit_log_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+        return events
 
 
 # Client for communicating with CredentialVault
@@ -473,14 +918,16 @@ class CredentialVaultClient:
             token_data = response["token"]
             return CredentialToken(
                 token_id=token_data["token_id"],
+                credential_id=token_data["credential_id"],
+                credential_version=int(token_data.get("credential_version", 1)),
                 credential_type=CredentialType(token_data["credential_type"]),
                 scope=CredentialScope(token_data["scope"]),
                 issued_at=token_data["issued_at"],
                 expires_at=token_data["expires_at"],
                 revoked=token_data["revoked"],
                 single_use=token_data["single_use"],
+                verification_context=dict(token_data.get("verification_context", {})),
                 qseal_signature=token_data["qseal_signature"],
-                encrypted_payload=token_data["encrypted_payload"]
             )
         else:
             print(f"[CredentialVaultClient] Error: {response.get('error')}")
@@ -491,11 +938,66 @@ class CredentialVaultClient:
         request = {"action": "verify_token", "token_id": token_id}
         return self._send_request(request)
 
+    def validate_token_use(
+        self,
+        token_id: str,
+        *,
+        sink_risk: str,
+        request_integrity: str,
+        provenance_node_hash: str,
+        policy_hash: str,
+        session_id: str,
+    ) -> Dict[str, Any]:
+        request = {
+            "action": "validate_token_use",
+            "token_id": token_id,
+            "sink_risk": sink_risk,
+            "request_integrity": request_integrity,
+            "provenance_node_hash": provenance_node_hash,
+            "policy_hash": policy_hash,
+            "session_id": session_id,
+        }
+        return self._send_request(request)
+
     def revoke_token(self, token_id: str, reason: str = "manual") -> bool:
         """Revoke a token"""
         request = {"action": "revoke_token", "token_id": token_id, "reason": reason}
         response = self._send_request(request)
         return response.get("success", False)
+
+    def create_credential(
+        self,
+        credential_id: str,
+        encrypted_credential: str,
+        *,
+        credential_type: str = "api_key",
+        ttl_seconds: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        request: Dict[str, Any] = {
+            "action": "create_credential",
+            "credential_id": credential_id,
+            "encrypted_credential": encrypted_credential,
+            "credential_type": credential_type,
+        }
+        if ttl_seconds is not None:
+            request["ttl_seconds"] = int(ttl_seconds)
+        return self._send_request(request)
+
+    def rotate_credential(self, credential_id: str, encrypted_credential: str) -> Dict[str, Any]:
+        request = {
+            "action": "rotate_credential",
+            "credential_id": credential_id,
+            "encrypted_credential": encrypted_credential,
+        }
+        return self._send_request(request)
+
+    def revoke_credential(self, credential_id: str, reason: str = "manual_credential_revocation") -> Dict[str, Any]:
+        request = {
+            "action": "revoke_credential",
+            "credential_id": credential_id,
+            "reason": reason,
+        }
+        return self._send_request(request)
 
     def report_psi_anomaly(
         self,

--- a/mvar/governor.py
+++ b/mvar/governor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -20,6 +21,10 @@ from mvar_core.provenance import (
 )
 from mvar_core.qseal import QSealSigner
 from mvar_core.sink_policy import PolicyOutcome
+from mvar_core.credential_vault import CredentialVaultClient
+
+
+_LOGGER = logging.getLogger("mvar.governor")
 
 
 @dataclass
@@ -49,6 +54,9 @@ class ExecutionDecision:
     enforcement_action: Optional[str] = None
     # used when decision is "annotate"
     # e.g. "block_until_approved"
+
+    vault_token_reference: Optional[dict[str, Any]] = None
+    # for credentials.access mediation; never contains raw credential material
 
 
 class ExecutionGovernor:
@@ -94,6 +102,11 @@ class ExecutionGovernor:
             execute_on_step_up=False,
         )
         self._qseal = QSealSigner()
+        self._vault_socket_path = str(
+            os.getenv("MVAR_VAULT_SOCKET_PATH", "/tmp/mvar_credential_vault.sock")
+        )
+        self._vault_default_ttl = int(os.getenv("MVAR_VAULT_TOKEN_TTL_SECONDS", "300"))
+        self._vault_single_use = os.getenv("MVAR_VAULT_TOKEN_SINGLE_USE", "1") == "1"
 
     def evaluate(self, request: dict[str, Any]) -> ExecutionDecision:
         req = dict(request or {})
@@ -205,6 +218,25 @@ class ExecutionGovernor:
             enforcement_action = None
             final_outcome = "ALLOW"
 
+        vault_token_reference: Optional[dict[str, Any]] = None
+        vault_trace: list[str] = []
+        if sink_type == "credentials.access":
+            (
+                decision,
+                reason_code,
+                enforcement_action,
+                final_outcome,
+                vault_token_reference,
+                vault_trace,
+            ) = self._mediate_credentials_access(
+                request=req,
+                base_decision=decision,
+                base_reason_code=reason_code,
+                integrity_level=integrity_level,
+                provenance=provenance,
+                policy_hash=str(getattr(auth, "policy_hash", "")),
+            )
+
         evaluation_trace = [
             f"input_integrity={integrity_level}",
             f"sink_classification={sink_classification}",
@@ -214,6 +246,7 @@ class ExecutionGovernor:
         raw_trace = getattr(auth, "evaluation_trace", None)
         if isinstance(raw_trace, list):
             evaluation_trace.extend([str(item) for item in raw_trace])
+        evaluation_trace.extend(vault_trace)
 
         return self._build_decision(
             decision=decision,
@@ -223,10 +256,195 @@ class ExecutionGovernor:
             integrity_level=integrity_level,
             evaluation_trace=evaluation_trace,
             enforcement_action=enforcement_action,
+            vault_token_reference=vault_token_reference,
         )
 
     def get_version(self) -> str:
         return __version__
+
+    @staticmethod
+    def _provenance_node_hash(provenance: dict[str, Any]) -> str:
+        node_id = str(provenance.get("node_id", ""))
+        if not node_id:
+            return ""
+        return hashlib.sha256(node_id.encode("utf-8")).hexdigest()
+
+    def _build_fallback_vault_reference(
+        self,
+        *,
+        credential_id: str,
+        scope: str,
+        ttl_seconds: int,
+        single_use: bool,
+        session_id: str,
+        provenance_node_hash: str,
+        policy_hash: str,
+        reason: str,
+    ) -> dict[str, Any]:
+        payload = {
+            "token_id": f"fallback_{hashlib.sha256(os.urandom(16)).hexdigest()[:16]}",
+            "mode": "fallback_no_vault",
+            "credential_id": credential_id,
+            "scope": scope,
+            "ttl_seconds": int(ttl_seconds),
+            "single_use": bool(single_use),
+            "session_binding": session_id,
+            "provenance_node_hash": provenance_node_hash,
+            "policy_hash": policy_hash,
+            "issued_at": datetime.now(timezone.utc).isoformat(),
+            "reason": reason,
+        }
+        canonical = str(payload).encode("utf-8")
+        seal = self._qseal.seal_result(
+            {
+                "proposal_digest": hashlib.sha256(canonical).hexdigest(),
+                "confidence": 1.0,
+                "trust_level": "medium",
+                "blocked": False,
+                "engine_used": "mvar-security",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "mode": self.profile_name,
+                "verification_trace": ["vault_fallback_reference"],
+            }
+        )
+        payload["qseal_signature"] = f"{seal.algorithm}:{seal.signature_hex}"
+        return payload
+
+    def _mediate_credentials_access(
+        self,
+        *,
+        request: dict[str, Any],
+        base_decision: str,
+        base_reason_code: str,
+        integrity_level: str,
+        provenance: dict[str, Any],
+        policy_hash: str,
+    ) -> tuple[str, str, Optional[str], str, Optional[dict[str, Any]], list[str]]:
+        """Route credentials.access through vault mediation; never return raw credential values."""
+        if base_decision != "allow":
+            return (
+                base_decision,
+                base_reason_code,
+                "block_until_approved" if base_decision == "annotate" else None,
+                "STEP_UP" if base_decision == "annotate" else "BLOCK",
+                None,
+                ["vault_mediation_skipped_non_allow_outcome"],
+            )
+
+        arguments = request.get("arguments", {}) if isinstance(request.get("arguments"), dict) else {}
+        credential_id = str(arguments.get("credential_id") or request.get("target") or "").strip()
+        if not credential_id:
+            return (
+                "block",
+                "VAULT_CREDENTIAL_ID_REQUIRED",
+                None,
+                "BLOCK",
+                None,
+                ["vault_mediation_failed_missing_credential_id"],
+            )
+
+        scope = str(arguments.get("scope", "read")).strip().lower() or "read"
+        ttl_seconds = int(arguments.get("ttl_seconds", self._vault_default_ttl))
+        single_use = bool(arguments.get("single_use", self._vault_single_use))
+        session_id = str(arguments.get("session_id") or request.get("session_id") or "").strip()
+        provenance_node_hash = self._provenance_node_hash(provenance)
+        integrity_norm = "trusted" if integrity_level.strip().lower() == "trusted" else "untrusted"
+        sink_risk = "critical"
+
+        verification_context = {
+            "credential_id": credential_id,
+            "scope": scope,
+            "ttl_seconds": ttl_seconds,
+            "single_use": single_use,
+            "session_id": session_id,
+            "provenance_node_hash": provenance_node_hash,
+            "policy_hash": policy_hash,
+            "integrity_at_issue": integrity_norm,
+            "sink_risk": sink_risk,
+        }
+
+        strict_override = bool(arguments.get("vault_fallback_override", False))
+
+        def _fallback(reason_code: str) -> tuple[str, str, Optional[str], str, Optional[dict[str, Any]], list[str]]:
+            if self.profile_name == "prod_locked":
+                return ("block", "VAULT_UNAVAILABLE_FAIL_CLOSED", None, "BLOCK", None, [f"vault_unavailable:{reason_code}"])
+            if self.profile_name == "dev_strict" and not strict_override:
+                return (
+                    "block",
+                    "VAULT_OVERRIDE_REQUIRED",
+                    None,
+                    "BLOCK",
+                    None,
+                    [f"vault_unavailable:{reason_code}", "vault_fallback_override_required"],
+                )
+            fallback_reason = "VAULT_FALLBACK_ALLOWED" if self.profile_name == "dev_balanced" else "VAULT_FALLBACK_OVERRIDE"
+            _LOGGER.warning(
+                "Vault unavailable for credentials.access; using fallback reference | profile=%s reason=%s",
+                self.profile_name,
+                reason_code,
+            )
+            ref = self._build_fallback_vault_reference(
+                credential_id=credential_id,
+                scope=scope,
+                ttl_seconds=ttl_seconds,
+                single_use=single_use,
+                session_id=session_id,
+                provenance_node_hash=provenance_node_hash,
+                policy_hash=policy_hash,
+                reason=reason_code,
+            )
+            return ("allow", fallback_reason, None, "ALLOW", ref, [f"vault_fallback:{reason_code}"])
+
+        try:
+            client = CredentialVaultClient(socket_path=self._vault_socket_path)
+            supplied_token_id = str(arguments.get("vault_token_id") or arguments.get("token_id") or "").strip()
+            if supplied_token_id:
+                validation = client.validate_token_use(
+                    supplied_token_id,
+                    sink_risk=sink_risk,
+                    request_integrity=integrity_norm,
+                    provenance_node_hash=provenance_node_hash,
+                    policy_hash=policy_hash,
+                    session_id=session_id,
+                )
+                if not validation.get("success") or not validation.get("valid"):
+                    return (
+                        "block",
+                        "VAULT_TOKEN_INVALID",
+                        None,
+                        "BLOCK",
+                        None,
+                        [f"vault_token_validation_failed:{validation.get('error', 'unknown')}"],
+                    )
+                return (
+                    "allow",
+                    "VAULT_TOKEN_VALIDATED",
+                    None,
+                    "ALLOW",
+                    {"token_id": supplied_token_id, "mode": "validated_reference"},
+                    ["vault_token_validated_use_time"],
+                )
+
+            token = client.issue_token(
+                credential_id=credential_id,
+                credential_type=str(arguments.get("credential_type", "api_key")),
+                scope=scope,
+                ttl_seconds=ttl_seconds,
+                single_use=single_use,
+                verification_context=verification_context,
+            )
+            if token is None:
+                return _fallback("token_issue_failed")
+            return (
+                "allow",
+                "VAULT_TOKEN_ISSUED",
+                None,
+                "ALLOW",
+                token.to_reference_dict(),
+                ["vault_token_issued"],
+            )
+        except Exception as exc:  # pragma: no cover - exercised in integration behavior
+            return _fallback(f"vault_unreachable:{exc}")
 
     def _register_default_capabilities(self, capability_runtime: CapabilityRuntime) -> None:
         capability_runtime.register_tool(
@@ -359,6 +577,7 @@ class ExecutionGovernor:
         integrity_level: str,
         evaluation_trace: list[str],
         enforcement_action: Optional[str],
+        vault_token_reference: Optional[dict[str, Any]] = None,
     ) -> ExecutionDecision:
         payload = {
             "decision": decision,
@@ -370,6 +589,7 @@ class ExecutionGovernor:
             "integrity_level": integrity_level,
             "evaluation_trace": evaluation_trace,
             "enforcement_action": enforcement_action,
+            "vault_token_reference": vault_token_reference,
         }
         canonical = str(payload).encode("utf-8")
         seal = self._qseal.seal_result(
@@ -395,4 +615,5 @@ class ExecutionGovernor:
             provenance=provenance,
             evaluation_trace=evaluation_trace,
             enforcement_action=enforcement_action,
+            vault_token_reference=vault_token_reference,
         )

--- a/tests/test_vaulted_execution.py
+++ b/tests/test_vaulted_execution.py
@@ -1,0 +1,329 @@
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import pytest
+
+from mvar.governor import ExecutionGovernor
+from mvar_core.credential_vault import CredentialVault
+from mvar_core.sink_policy import PolicyOutcome
+
+
+@dataclass
+class _FakePreDecision:
+    execution_token: Dict[str, Any] | None = None
+
+
+@dataclass
+class _FakeAuthDecision:
+    outcome: PolicyOutcome = PolicyOutcome.ALLOW
+    evaluation_trace: list[str] | None = None
+    policy_hash: str = "policy_hash_test"
+
+
+class _FakeToken:
+    def __init__(self, payload: dict[str, Any]):
+        self._payload = payload
+
+    def to_reference_dict(self) -> dict[str, Any]:
+        return dict(self._payload)
+
+
+class _VaultClientSuccess:
+    def __init__(self, socket_path: str):
+        self.socket_path = socket_path
+
+    def issue_token(self, **kwargs: Any):
+        payload = {
+            "token_id": "tok_abc123",
+            "credential_id": kwargs["credential_id"],
+            "credential_version": 1,
+            "credential_type": "api_key",
+            "scope": kwargs["scope"],
+            "issued_at": 1.0,
+            "expires_at": 301.0,
+            "revoked": False,
+            "single_use": kwargs["single_use"],
+            "verification_context": kwargs["verification_context"],
+            "qseal_signature": {"algorithm": "ed25519", "signature": "ed25519:abcd"},
+            "is_valid": True,
+            "time_remaining": 300.0,
+        }
+        return _FakeToken(payload)
+
+    def validate_token_use(self, *_args: Any, **_kwargs: Any):
+        return {"success": True, "valid": True}
+
+
+class _VaultClientUnavailable:
+    def __init__(self, socket_path: str):
+        raise OSError(f"unreachable socket {socket_path}")
+
+
+@pytest.fixture
+def _restore_env():
+    snapshot = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(snapshot)
+
+
+def _force_governor_allow(governor: ExecutionGovernor) -> None:
+    governor.adapter.evaluate = lambda **_kwargs: _FakePreDecision()  # type: ignore[assignment]
+    governor.adapter.authorize_execution = lambda **_kwargs: _FakeAuthDecision(  # type: ignore[assignment]
+        outcome=PolicyOutcome.ALLOW,
+        evaluation_trace=["forced_allow_for_vault_mediation"],
+        policy_hash="policy_hash_test",
+    )
+
+
+def test_governor_credentials_access_returns_vault_token_reference_without_raw_material(monkeypatch, _restore_env):
+    monkeypatch.setattr("mvar.governor.CredentialVaultClient", _VaultClientSuccess)
+    governor = ExecutionGovernor(policy_profile="dev_balanced")
+    _force_governor_allow(governor)
+
+    decision = governor.evaluate(
+        {
+            "sink_type": "credentials.access",
+            "target": "payments_api_key",
+            "session_id": "sess-1",
+            "arguments": {
+                "credential_id": "payments_api_key",
+                "scope": "read",
+                "single_use": True,
+            },
+            "prompt_provenance": {"source": "user_request", "taint_level": "trusted"},
+        }
+    )
+
+    assert decision.decision == "allow"
+    assert decision.reason_code == "VAULT_TOKEN_ISSUED"
+    assert decision.vault_token_reference is not None
+    ref = dict(decision.vault_token_reference)
+    assert ref["credential_id"] == "payments_api_key"
+    assert ref["scope"] == "read"
+    assert "verification_context" in ref
+    assert "provenance_node_hash" in ref["verification_context"]
+    assert "policy_hash" in ref["verification_context"]
+    assert "encrypted_payload" not in ref
+    assert "raw_credential" not in ref
+
+
+def test_governor_prod_locked_fails_closed_when_vault_unavailable(monkeypatch, _restore_env):
+    monkeypatch.setattr("mvar.governor.CredentialVaultClient", _VaultClientUnavailable)
+    governor = ExecutionGovernor(policy_profile="prod_locked")
+    _force_governor_allow(governor)
+
+    decision = governor.evaluate(
+        {
+            "sink_type": "credentials.access",
+            "target": "db_password",
+            "arguments": {"credential_id": "db_password"},
+            "prompt_provenance": {"source": "user_request", "taint_level": "trusted"},
+        }
+    )
+
+    assert decision.decision == "block"
+    assert decision.reason_code == "VAULT_UNAVAILABLE_FAIL_CLOSED"
+    assert decision.vault_token_reference is None
+
+
+def test_governor_dev_strict_requires_explicit_override_for_vault_fallback(monkeypatch, _restore_env):
+    monkeypatch.setattr("mvar.governor.CredentialVaultClient", _VaultClientUnavailable)
+    governor = ExecutionGovernor(policy_profile="dev_strict")
+    _force_governor_allow(governor)
+
+    blocked = governor.evaluate(
+        {
+            "sink_type": "credentials.access",
+            "target": "prod_key",
+            "arguments": {"credential_id": "prod_key"},
+            "prompt_provenance": {"source": "user_request", "taint_level": "trusted"},
+        }
+    )
+    assert blocked.decision == "block"
+    assert blocked.reason_code == "VAULT_OVERRIDE_REQUIRED"
+
+    allowed = governor.evaluate(
+        {
+            "sink_type": "credentials.access",
+            "target": "prod_key",
+            "arguments": {
+                "credential_id": "prod_key",
+                "vault_fallback_override": True,
+            },
+            "prompt_provenance": {"source": "user_request", "taint_level": "trusted"},
+        }
+    )
+    assert allowed.decision == "allow"
+    assert allowed.reason_code == "VAULT_FALLBACK_OVERRIDE"
+    assert allowed.vault_token_reference is not None
+    assert allowed.vault_token_reference.get("mode") == "fallback_no_vault"
+
+
+def test_vault_persists_credentials_encrypted_at_rest(tmp_path):
+    vault = CredentialVault(vault_dir=str(tmp_path), require_caller_auth=False)
+    vault.add_credential("service_token", "super-secret-material")
+
+    encrypted_path = tmp_path / "credentials.enc"
+    assert encrypted_path.exists()
+    raw_bytes = encrypted_path.read_bytes()
+    assert b"super-secret-material" not in raw_bytes
+
+    reloaded = CredentialVault(vault_dir=str(tmp_path), require_caller_auth=False)
+    assert "service_token" in reloaded.credentials
+    assert reloaded.credentials["service_token"].encrypted_payload == "super-secret-material"
+
+
+def test_vault_rotation_and_revocation_invalidate_existing_tokens(tmp_path):
+    vault = CredentialVault(vault_dir=str(tmp_path), require_caller_auth=False)
+    vault.add_credential("ops_key", "ciphertext-v1")
+
+    issued = vault._handle_issue_token(
+        {
+            "credential_id": "ops_key",
+            "credential_type": "api_key",
+            "scope": "read",
+            "ttl_seconds": 300,
+            "single_use": False,
+            "verification_context": {
+                "session_id": "s1",
+                "provenance_node_hash": "prov",
+                "policy_hash": "phash",
+                "integrity_at_issue": "trusted",
+                "sink_risk": "critical",
+            },
+        }
+    )
+    assert issued["success"] is True
+    token_id = issued["token"]["token_id"]
+
+    rotated = vault.rotate_credential("ops_key", "ciphertext-v2")
+    assert rotated is not None
+    assert rotated["version"] == 2
+
+    stale = vault._handle_verify_token({"token_id": token_id})
+    assert stale["success"] is False
+    assert stale["error"] == "credential_rotated_token_stale"
+
+    assert vault.revoke_credential("ops_key", reason="incident_response") is True
+    refused = vault._handle_issue_token(
+        {
+            "credential_id": "ops_key",
+            "credential_type": "api_key",
+            "scope": "read",
+            "ttl_seconds": 300,
+            "single_use": False,
+            "verification_context": {},
+        }
+    )
+    assert refused["success"] is False
+
+
+def test_vault_circuit_breaker_revokes_all_credentials_and_blocks_subsequent_access(tmp_path):
+    vault = CredentialVault(vault_dir=str(tmp_path), require_caller_auth=False)
+    vault.add_credential("a", "enc-a")
+    vault.add_credential("b", "enc-b")
+
+    vault._handle_issue_token(
+        {
+            "credential_id": "a",
+            "credential_type": "api_key",
+            "scope": "read",
+            "ttl_seconds": 300,
+            "single_use": False,
+            "verification_context": {"session_id": "sess-x"},
+        }
+    )
+
+    anomaly = vault._handle_psi_anomaly(
+        {
+            "psi_current": 0.95,
+            "psi_baseline": 0.45,
+            "psi_sigma": 0.05,
+            "session_id": "sess-x",
+        }
+    )
+    assert anomaly["success"] is True
+    assert anomaly["anomaly_detected"] is True
+
+    denied = vault._handle_issue_token(
+        {
+            "credential_id": "a",
+            "credential_type": "api_key",
+            "scope": "read",
+            "ttl_seconds": 300,
+            "single_use": False,
+            "verification_context": {"session_id": "sess-x"},
+        }
+    )
+    assert denied["success"] is False
+
+
+def test_vault_token_validation_blocks_untrusted_provenance_at_critical_sink(tmp_path):
+    vault = CredentialVault(vault_dir=str(tmp_path), require_caller_auth=False)
+    vault.add_credential("ci_secret", "enc-ci")
+
+    issued = vault._handle_issue_token(
+        {
+            "credential_id": "ci_secret",
+            "credential_type": "api_key",
+            "scope": "read",
+            "ttl_seconds": 300,
+            "single_use": False,
+            "verification_context": {
+                "session_id": "sess-9",
+                "provenance_node_hash": "prov-hash",
+                "policy_hash": "policy-hash",
+                "integrity_at_issue": "untrusted",
+                "sink_risk": "critical",
+            },
+        }
+    )
+    assert issued["success"] is True
+    token_id = issued["token"]["token_id"]
+
+    blocked = vault._handle_validate_token_use(
+        {
+            "token_id": token_id,
+            "sink_risk": "critical",
+            "request_integrity": "trusted",
+            "provenance_node_hash": "prov-hash",
+            "policy_hash": "policy-hash",
+            "session_id": "sess-9",
+        }
+    )
+    assert blocked["success"] is False
+    assert blocked["error"] == "untrusted_to_critical_sink"
+
+
+def test_vault_audit_log_is_signed_append_only_chain(tmp_path):
+    vault = CredentialVault(vault_dir=str(tmp_path), require_caller_auth=False)
+    vault.add_credential("audit_key", "enc-audit")
+    vault._handle_issue_token(
+        {
+            "credential_id": "audit_key",
+            "credential_type": "api_key",
+            "scope": "read",
+            "ttl_seconds": 300,
+            "single_use": True,
+            "verification_context": {"session_id": "audit-sess"},
+        }
+    )
+
+    entries = vault.get_audit_log()
+    assert len(entries) >= 2
+    previous_signature = ""
+    for entry in entries:
+        algorithm = entry["qseal_algorithm"]
+        signature = entry["qseal_signature"]
+        assert signature.startswith(f"{algorithm}:")
+        assert isinstance(entry.get("qseal_verified"), bool)
+        assert entry.get("prev_signature", "") == previous_signature
+        previous_signature = signature
+
+    assert (tmp_path / "audit.jsonl").exists()
+    raw_text = (tmp_path / "audit.jsonl").read_text(encoding="utf-8")
+    parsed = [json.loads(line) for line in raw_text.splitlines() if line.strip()]
+    assert parsed == entries


### PR DESCRIPTION
## Summary
- route `credentials.access` through vault token mediation in `ExecutionGovernor`
- harden `CredentialVault` with durable encrypted storage, caller auth, lifecycle controls, signed append-only audit log, and anomaly-triggered mass revocation
- bind token issuance/validation to provenance+policy context and block untrusted-to-critical token use
- add contract tests for raw-credential invariant and vault mediation behavior

## Validation
- `./.venv/bin/python -m pytest -q`
